### PR TITLE
feat(database): データベーススキーマ設計とADR004の追加

### DIFF
--- a/docs/adr/ADR004-database-schema.md
+++ b/docs/adr/ADR004-database-schema.md
@@ -1,0 +1,156 @@
+# データベーススキーマ設計
+
+## ステータス
+
+決定済み
+
+## コンテキスト
+
+GitHub リポジトリ監視アプリケーションのデータベーススキーマを設計する必要がある。将来的にNPMパッケージなど他のデータソースにも対応したいが、初期実装ではGitHubリポジトリのみに集中する。
+
+### 主要な要件
+
+- 既存のAuth0認証システムとの統合
+- ユーザーがGitHubリポジトリを監視できる機能
+- リポジトリのイベント（リリース、PR、Issue等）の追跡
+- ユーザー設定とブックマーク機能
+- 通知システム
+- 将来的な拡張性（NPM等の他データソース対応）
+
+## 決定
+
+### アーキテクチャパターン
+
+**Data Sourceパターンの採用**
+- 将来のNPM対応を見据え、DataSourceという抽象概念を導入
+- GitHubリポジトリ固有の情報は`repositories`テーブルに分離
+- 1対1の関係で`data_sources` ↔ `repositories`を設計
+
+### ID管理
+
+**UUIDv7をアプリケーション側で生成**
+- PostgreSQLの`gen_random_uuid()`はUUIDv4を生成するため不採用
+- より効率的なUUIDv7をアプリケーション側で生成
+- テーブル定義では`DEFAULT`値なし
+
+### デフォルト値戦略
+
+**段階的なデフォルト値設定**
+- 文字列型: 空文字（`''`）
+- 数値型: 0
+- 日付型: `CURRENT_TIMESTAMP`または`NULL`
+- ユーザー設定: アプリケーション側でデフォルト管理（DB側デフォルトなし）
+
+### セキュリティ方針
+
+**アクセストークンの非保存**
+- GitHubアクセストークンはDBに保存しない
+- Auth0経由での認証を検討
+- プライベートリポジトリ対応は将来のTODO
+
+### データ型選択
+
+**JSON型の慎重な活用**
+- まずは標準的なカラム設計を優先
+- 真に必要な場合のみJSONを検討
+- 初期実装では極力避ける
+
+## 考慮した選択肢
+
+### ID生成方式
+
+#### PostgreSQL側でのUUID生成
+- `gen_random_uuid()`はUUIDv4を生成
+- ソート性能が劣るため不採用
+
+#### アプリケーション側でのUUID生成
+- UUIDv7の採用でソート性能を改善
+- アプリケーション側で一意性管理
+- 採用
+
+### データソース設計
+
+#### 単一テーブルでの管理
+- GitHubとNPMの情報を一つのテーブルで管理
+- カラムの無駄が多く、拡張性に劣る
+
+#### DataSourceパターン
+- 抽象的な`data_sources`テーブル
+- 具体的な`repositories`、`packages`テーブル
+- 拡張性が高く採用
+
+### アクセストークン管理
+
+#### データベースでの暗号化保存
+- セキュリティリスクが高い
+- 管理コストが高い
+
+#### Auth0経由での管理
+- セキュリティリスクを軽減
+- 実装コストは高いが長期的にメリット大
+- 採用
+
+## 結果・影響
+
+### ポジティブな影響
+
+- **拡張性**: 新しいデータソース（NPM、Docker Hub等）の追加が容易
+- **セキュリティ**: アクセストークンを直接保存しないことでリスク軽減
+- **パフォーマンス**: UUIDv7によるソート性能の改善
+- **保守性**: 明確な関係性とデータ分離
+
+### 考慮事項
+
+- **実装複雑性**: DataSourceパターンにより初期実装が複雑化
+- **パフォーマンス**: JOIN操作の増加
+- **データ整合性**: 複数テーブル間の整合性管理が必要
+
+### 今後の対応
+
+1. **短期（現在のフェーズ）**
+   - GitHub リポジトリ監視機能の実装
+   - Drizzle ORMでのスキーマ実装
+   - 基本的なCRUD操作の実装
+
+2. **中期（機能拡張フェーズ）**
+   - パフォーマンス最適化
+   - インデックス戦略の見直し
+   - Auth0 GitHub連携の実装
+
+3. **長期（スケール対応）**
+   - NPMパッケージ対応
+   - パーティショニング戦略
+   - 読み取り専用レプリカの検討
+
+## 実装方針
+
+### テーブル構成
+
+1. **users**: ユーザー情報（Auth0連携）
+2. **data_sources**: データソース抽象管理
+3. **repositories**: GitHubリポジトリ詳細
+4. **user_watches**: ユーザー監視設定（多対多）
+5. **events**: リポジトリイベント
+6. **user_preferences**: ユーザー設定
+7. **bookmarks**: ブックマーク機能
+8. **notifications**: 通知履歴
+
+### 関係性
+
+- **1対1**: `data_sources` ↔ `repositories`、`users` ↔ `user_preferences`
+- **1対多**: 各親テーブルから子テーブルへ
+- **多対多**: `users` ↔ `data_sources`（`user_watches`経由）
+
+### インデックス戦略
+
+- 外部キーカラム
+- 検索頻度の高いカラム（email、github_username等）
+- 日付カラム（created_at、last_activity_at等）
+- 複合インデックス（bookmark_type + target_id等）
+
+## 参考資料
+
+- [Drizzle ORM Documentation](https://orm.drizzle.team/)
+- [PostgreSQL UUID Functions](https://www.postgresql.org/docs/current/functions-uuid.html)
+- [Auth0 Best Practices](https://auth0.com/docs/best-practices)
+- [Database Design Patterns](https://www.martinfowler.com/articles/dblogic.html)

--- a/docs/database-schema-design.md
+++ b/docs/database-schema-design.md
@@ -3,54 +3,65 @@
 ## エンティティ概要
 
 ### 1. Users（ユーザー）
+
 既存のsessionsテーブルの情報を基に、ユーザー情報を管理
 
 ### 2. Data_Sources（データソース）
+
 監視対象のデータソース（GitHub）の種別管理
 ※将来的にNPM等も対応予定
 
 ### 3. Repositories（リポジトリ）
+
 GitHubリポジトリ情報（data_sources経由で管理）
 
 ### 4. User_Watches（ユーザー監視設定）
+
 ユーザーが監視している対象の管理（多対多の関係）
 
 ### 5. Events（イベント）
+
 各データソースで発生したイベント（リリース、PR、Issue等）
 
 ### 6. User_Preferences（ユーザー設定）
+
 通知設定、言語設定等のユーザー固有設定
 
 ### 7. Bookmarks（ブックマーク）
+
 ユーザーがブックマークしたイベントやデータソース
 
 ### 8. Notifications（通知）
+
 ユーザーへの通知履歴
 
 ## 将来の拡張計画
 
 ### NPM対応（将来実装予定）
+
 - Packages（パッケージ）テーブル
 - NPM固有のイベント種別
 
 ## 詳細テーブル設計
 
 ### users
+
 ```sql
 CREATE TABLE users (
     id UUID PRIMARY KEY,                             -- UUIDv7をアプリケーション側で生成
     auth0_user_id VARCHAR(255) UNIQUE NOT NULL,     -- Auth0のuser_id
     email VARCHAR(255) UNIQUE NOT NULL,
-    name VARCHAR(255) DEFAULT '',
-    avatar_url TEXT DEFAULT '',
-    github_username VARCHAR(255) DEFAULT '',        -- GitHubユーザー名
-    timezone VARCHAR(50) DEFAULT '',
+    name VARCHAR(255) NOT NULL,
+    avatar_url TEXT NOT NULL,
+    github_username VARCHAR(255) NOT NULL,        -- GitHubユーザー名
+    timezone VARCHAR(50) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 ```
 
 ### data_sources
+
 ```sql
 CREATE TABLE data_sources (
     id UUID PRIMARY KEY,                             -- UUIDv7をアプリケーション側で生成
@@ -68,6 +79,7 @@ CREATE TABLE data_sources (
 ```
 
 ### repositories
+
 ```sql
 CREATE TABLE repositories (
     id UUID PRIMARY KEY,                             -- UUIDv7をアプリケーション側で生成
@@ -88,6 +100,7 @@ CREATE TABLE repositories (
 ```
 
 ### user_watches
+
 ```sql
 CREATE TABLE user_watches (
     id UUID PRIMARY KEY,                             -- UUIDv7をアプリケーション側で生成
@@ -105,6 +118,7 @@ CREATE TABLE user_watches (
 ```
 
 ### events
+
 ```sql
 CREATE TABLE events (
     id UUID PRIMARY KEY,                             -- UUIDv7をアプリケーション側で生成
@@ -125,6 +139,7 @@ CREATE TABLE events (
 ```
 
 ### user_preferences
+
 ```sql
 CREATE TABLE user_preferences (
     id UUID PRIMARY KEY,                             -- UUIDv7をアプリケーション側で生成
@@ -141,6 +156,7 @@ CREATE TABLE user_preferences (
 ```
 
 ### bookmarks
+
 ```sql
 CREATE TABLE bookmarks (
     id UUID PRIMARY KEY,                             -- UUIDv7をアプリケーション側で生成
@@ -154,6 +170,7 @@ CREATE TABLE bookmarks (
 ```
 
 ### notifications
+
 ```sql
 CREATE TABLE notifications (
     id UUID PRIMARY KEY,                             -- UUIDv7をアプリケーション側で生成
@@ -171,6 +188,7 @@ CREATE TABLE notifications (
 ## インデックス設計
 
 ### パフォーマンス最適化のためのインデックス
+
 ```sql
 -- users
 CREATE INDEX idx_users_auth0_user_id ON users(auth0_user_id);
@@ -211,10 +229,12 @@ CREATE INDEX idx_bookmarks_type_target ON bookmarks(bookmark_type, target_id);
 ## 関係性
 
 ### 1対1の関係
+
 - data_sources ↔ repositories (1データソースは1つのGitHubリポジトリ)
 - users ↔ user_preferences (1ユーザーは1つの設定)
 
 ### 1対多の関係
+
 - data_sources → user_watches (1データソースは複数のユーザーに監視される)
 - data_sources → events (1データソースは複数のイベントを持つ)
 - users → user_watches (1ユーザーは複数のデータソースを監視)
@@ -222,6 +242,7 @@ CREATE INDEX idx_bookmarks_type_target ON bookmarks(bookmark_type, target_id);
 - events → notifications (1イベントは複数の通知を生成可能)
 
 ### 多対多の関係
+
 - users ↔ data_sources (user_watchesテーブル経由)
 
 ## データ整合性制約
@@ -250,6 +271,7 @@ CREATE INDEX idx_bookmarks_type_target ON bookmarks(bookmark_type, target_id);
 ## データソース別の特徴
 
 ### GitHub Repository（現在実装対象）
+
 - source_type: 'github_repository'
 - source_id: 'owner/repo'
 - repositories テーブルに詳細情報を格納
@@ -258,12 +280,14 @@ CREATE INDEX idx_bookmarks_type_target ON bookmarks(bookmark_type, target_id);
 ### 将来の拡張候補
 
 #### NPM Package（将来実装予定）
-- source_type: 'npm_package'  
+
+- source_type: 'npm_package'
 - source_id: 'package-name'
 - packages テーブルに詳細情報を格納
 - イベント: npm_publish, security_alert
 
 #### その他の検討候補
+
 - Docker Hub
 - PyPI
 - Rust Crates

--- a/docs/database-schema-design.md
+++ b/docs/database-schema-design.md
@@ -1,0 +1,270 @@
+# データベーススキーマ設計
+
+## エンティティ概要
+
+### 1. Users（ユーザー）
+既存のsessionsテーブルの情報を基に、ユーザー情報を管理
+
+### 2. Data_Sources（データソース）
+監視対象のデータソース（GitHub）の種別管理
+※将来的にNPM等も対応予定
+
+### 3. Repositories（リポジトリ）
+GitHubリポジトリ情報（data_sources経由で管理）
+
+### 4. User_Watches（ユーザー監視設定）
+ユーザーが監視している対象の管理（多対多の関係）
+
+### 5. Events（イベント）
+各データソースで発生したイベント（リリース、PR、Issue等）
+
+### 6. User_Preferences（ユーザー設定）
+通知設定、言語設定等のユーザー固有設定
+
+### 7. Bookmarks（ブックマーク）
+ユーザーがブックマークしたイベントやデータソース
+
+### 8. Notifications（通知）
+ユーザーへの通知履歴
+
+## 将来の拡張計画
+
+### NPM対応（将来実装予定）
+- Packages（パッケージ）テーブル
+- NPM固有のイベント種別
+
+## 詳細テーブル設計
+
+### users
+```sql
+CREATE TABLE users (
+    id UUID PRIMARY KEY,                             -- UUIDv7をアプリケーション側で生成
+    auth0_user_id VARCHAR(255) UNIQUE NOT NULL,     -- Auth0のuser_id
+    email VARCHAR(255) UNIQUE NOT NULL,
+    name VARCHAR(255) DEFAULT '',
+    avatar_url TEXT DEFAULT '',
+    github_username VARCHAR(255) DEFAULT '',        -- GitHubユーザー名
+    timezone VARCHAR(50) DEFAULT '',
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### data_sources
+```sql
+CREATE TABLE data_sources (
+    id UUID PRIMARY KEY,                             -- UUIDv7をアプリケーション側で生成
+    source_type VARCHAR(50) NOT NULL,               -- 'github_repository'
+    source_id VARCHAR(500) NOT NULL,                -- GitHubの場合は'owner/repo'
+    name VARCHAR(255) NOT NULL,
+    description TEXT DEFAULT '',
+    url TEXT NOT NULL,                               -- データソースのURL
+    is_private BOOLEAN DEFAULT false,
+    last_activity_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(source_type, source_id)
+);
+```
+
+### repositories
+```sql
+CREATE TABLE repositories (
+    id UUID PRIMARY KEY,                             -- UUIDv7をアプリケーション側で生成
+    data_source_id UUID NOT NULL REFERENCES data_sources(id) ON DELETE CASCADE,
+    github_id BIGINT UNIQUE NOT NULL,               -- GitHubのリポジトリID
+    full_name VARCHAR(255) NOT NULL,                -- "owner/repo"形式
+    owner VARCHAR(255) NOT NULL,                    -- リポジトリオーナー
+    html_url TEXT NOT NULL,                         -- GitHub HTMLページURL
+    clone_url TEXT DEFAULT '',
+    ssh_url TEXT DEFAULT '',
+    language VARCHAR(100) DEFAULT '',               -- 主要プログラミング言語
+    stars_count INTEGER DEFAULT 0,                  -- スター数
+    forks_count INTEGER DEFAULT 0,
+    open_issues_count INTEGER DEFAULT 0,
+    is_fork BOOLEAN DEFAULT false,
+    default_branch VARCHAR(255) DEFAULT 'main'
+);
+```
+
+### user_watches
+```sql
+CREATE TABLE user_watches (
+    id UUID PRIMARY KEY,                             -- UUIDv7をアプリケーション側で生成
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    data_source_id UUID NOT NULL REFERENCES data_sources(id) ON DELETE CASCADE,
+    notification_enabled BOOLEAN DEFAULT true,
+    watch_releases BOOLEAN DEFAULT true,
+    watch_issues BOOLEAN DEFAULT false,
+    watch_pull_requests BOOLEAN DEFAULT false,
+    watch_pushes BOOLEAN DEFAULT false,
+    watch_security_alerts BOOLEAN DEFAULT true,
+    added_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, data_source_id)
+);
+```
+
+### events
+```sql
+CREATE TABLE events (
+    id UUID PRIMARY KEY,                             -- UUIDv7をアプリケーション側で生成
+    data_source_id UUID NOT NULL REFERENCES data_sources(id) ON DELETE CASCADE,
+    github_event_id VARCHAR(255) DEFAULT '',        -- GitHubのイベントID（重複防止）
+    event_type VARCHAR(50) NOT NULL,                -- 'release', 'issue', 'pull_request', 'push', 'security_alert'
+    title VARCHAR(500) NOT NULL,
+    body TEXT DEFAULT '',
+    html_url TEXT DEFAULT '',
+    actor_login VARCHAR(255) DEFAULT '',            -- イベントを実行したユーザー
+    actor_avatar_url TEXT DEFAULT '',
+    version VARCHAR(50) DEFAULT '',                 -- リリースバージョン
+    severity VARCHAR(20) DEFAULT '',                -- セキュリティアラートの重要度等
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(data_source_id, github_event_id, event_type)
+);
+```
+
+### user_preferences
+```sql
+CREATE TABLE user_preferences (
+    id UUID PRIMARY KEY,                             -- UUIDv7をアプリケーション側で生成
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    language VARCHAR(10),                           -- 表示言語（デフォルトなし）
+    email_notifications BOOLEAN,                    -- メール通知（デフォルトなし）
+    digest_frequency VARCHAR(20),                   -- 'daily', 'weekly', 'none'（デフォルトなし）
+    timezone VARCHAR(50),                           -- タイムゾーン（デフォルトなし）
+    theme VARCHAR(20),                              -- 'light', 'dark', 'system'（デフォルトなし）
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id)
+);
+```
+
+### bookmarks
+```sql
+CREATE TABLE bookmarks (
+    id UUID PRIMARY KEY,                             -- UUIDv7をアプリケーション側で生成
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    bookmark_type VARCHAR(20) NOT NULL,             -- 'event', 'data_source'
+    target_id UUID NOT NULL,                        -- event_id or data_source_id
+    notes TEXT DEFAULT '',
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, bookmark_type, target_id)
+);
+```
+
+### notifications
+```sql
+CREATE TABLE notifications (
+    id UUID PRIMARY KEY,                             -- UUIDv7をアプリケーション側で生成
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    event_id UUID REFERENCES events(id) ON DELETE CASCADE,
+    title VARCHAR(500) NOT NULL,
+    message TEXT DEFAULT '',
+    notification_type VARCHAR(50) NOT NULL,         -- 'email', 'in_app'
+    is_read BOOLEAN DEFAULT false,
+    sent_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+## インデックス設計
+
+### パフォーマンス最適化のためのインデックス
+```sql
+-- users
+CREATE INDEX idx_users_auth0_user_id ON users(auth0_user_id);
+CREATE INDEX idx_users_email ON users(email);
+CREATE INDEX idx_users_github_username ON users(github_username);
+
+-- data_sources
+CREATE INDEX idx_data_sources_type ON data_sources(source_type);
+CREATE INDEX idx_data_sources_source_id ON data_sources(source_id);
+CREATE INDEX idx_data_sources_last_activity ON data_sources(last_activity_at);
+
+-- repositories
+CREATE INDEX idx_repositories_data_source_id ON repositories(data_source_id);
+CREATE INDEX idx_repositories_github_id ON repositories(github_id);
+CREATE INDEX idx_repositories_full_name ON repositories(full_name);
+CREATE INDEX idx_repositories_owner ON repositories(owner);
+
+-- user_watches
+CREATE INDEX idx_user_watches_user_id ON user_watches(user_id);
+CREATE INDEX idx_user_watches_data_source_id ON user_watches(data_source_id);
+
+-- events
+CREATE INDEX idx_events_data_source_id ON events(data_source_id);
+CREATE INDEX idx_events_type ON events(event_type);
+CREATE INDEX idx_events_created_at ON events(created_at);
+CREATE INDEX idx_events_github_event_id ON events(github_event_id);
+
+-- notifications
+CREATE INDEX idx_notifications_user_id ON notifications(user_id);
+CREATE INDEX idx_notifications_is_read ON notifications(is_read);
+CREATE INDEX idx_notifications_created_at ON notifications(created_at);
+
+-- bookmarks
+CREATE INDEX idx_bookmarks_user_id ON bookmarks(user_id);
+CREATE INDEX idx_bookmarks_type_target ON bookmarks(bookmark_type, target_id);
+```
+
+## 関係性
+
+### 1対1の関係
+- data_sources ↔ repositories (1データソースは1つのGitHubリポジトリ)
+- users ↔ user_preferences (1ユーザーは1つの設定)
+
+### 1対多の関係
+- data_sources → user_watches (1データソースは複数のユーザーに監視される)
+- data_sources → events (1データソースは複数のイベントを持つ)
+- users → user_watches (1ユーザーは複数のデータソースを監視)
+- users → notifications (1ユーザーは複数の通知を受信)
+- events → notifications (1イベントは複数の通知を生成可能)
+
+### 多対多の関係
+- users ↔ data_sources (user_watchesテーブル経由)
+
+## データ整合性制約
+
+1. **外部キー制約**: 参照整合性を保証
+2. **UNIQUE制約**: 重複データの防止
+3. **NOT NULL制約**: 必須フィールドの保証
+4. **DEFAULT値**: 適切なデフォルト値の設定
+5. **CHECK制約**: data_sources.source_typeは定義済みの値のみ許可
+
+## セキュリティ考慮事項
+
+1. **アクセストークンの管理**: GitHubアクセストークンはDBに保存せず、Auth0経由での認証を検討
+2. **プライベートリポジトリ**: TODO - プライベートリポジトリの監視方法を検討（Auth0 GitHub連携活用等）
+3. **索引の最適化**: 個人情報を含むカラムのインデックスは最小限に
+4. **データ保持期間**: 古いイベントや通知の自動削除機能の検討
+
+## 拡張性考慮事項
+
+1. **JSON型の活用**: 慎重に検討して採用。まずは標準的なカラム設計を優先し、真に必要な場合のみJSONを検討
+2. **ソース追加の容易性**: 新しいデータソース（NPM、Docker Hub、PyPI等）の追加が容易
+3. **パーティショニング**: 将来的にeventsテーブルの日付ベースパーティショニング
+4. **読み取り専用レプリカ**: 分析クエリ用の読み取り専用インスタンス検討
+5. **UUIDv7**: より効率的なUUID生成方式の採用検討
+
+## データソース別の特徴
+
+### GitHub Repository（現在実装対象）
+- source_type: 'github_repository'
+- source_id: 'owner/repo'
+- repositories テーブルに詳細情報を格納
+- イベント: release, issue, pull_request, push, security_alert
+
+### 将来の拡張候補
+
+#### NPM Package（将来実装予定）
+- source_type: 'npm_package'  
+- source_id: 'package-name'
+- packages テーブルに詳細情報を格納
+- イベント: npm_publish, security_alert
+
+#### その他の検討候補
+- Docker Hub
+- PyPI
+- Rust Crates
+- Go Modules


### PR DESCRIPTION
## Summary

GitHub リポジトリ監視アプリケーションのデータベーススキーマを設計し、ADR004として設計判断を文書化しました。

### 主な変更点

- **DataSourceパターンの採用**: 将来のNPM対応を見据えた拡張可能な設計
- **8つのテーブル設計**: users, data_sources, repositories, user_watches, events, user_preferences, bookmarks, notifications
- **UUIDv7対応**: アプリケーション側でのID生成方式
- **セキュリティ強化**: GitHubアクセストークンのDB保存を回避
- **ADR004作成**: 設計判断の根拠と考慮事項を文書化

### テーブル構成

1. **users**: Auth0連携ユーザー情報
2. **data_sources**: 監視対象の抽象管理（GitHub、将来のNPM等）
3. **repositories**: GitHubリポジトリ詳細情報
4. **user_watches**: ユーザー監視設定（多対多関係）
5. **events**: リポジトリイベント（リリース、PR、Issue等）
6. **user_preferences**: ユーザー個別設定
7. **bookmarks**: ブックマーク機能
8. **notifications**: 通知履歴

### 設計の特徴

- **拡張性**: 新しいデータソース（NPM、Docker Hub等）への対応が容易
- **セキュリティ**: 機密トークンの適切な管理方針
- **パフォーマンス**: 適切なインデックス設計
- **データ整合性**: 外部キー制約とユニーク制約

## Test plan

- [x] スキーマ設計の完了
- [x] ADR004の作成
- [ ] Drizzle ORMでの実装（次のフェーズ）
- [ ] マイグレーションスクリプトの作成（次のフェーズ）
- [ ] リポジトリパターンの実装（次のフェーズ）

🤖 Generated with [Claude Code](https://claude.ai/code)