### PR TITLE
feat(CHASE-66): GitHubリポジトリ追加APIの設計検討

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,2 @@
-# API Keys (Required to enable respective provider)
-ANTHROPIC_API_KEY="your_anthropic_api_key_here"       # Required: Format: sk-ant-api03-...
-PERPLEXITY_API_KEY="your_perplexity_api_key_here"     # Optional: Format: pplx-...
-OPENAI_API_KEY="your_openai_api_key_here"             # Optional, for OpenAI/OpenRouter models. Format: sk-proj-...
-GOOGLE_API_KEY="your_google_api_key_here"             # Optional, for Google Gemini models.
-MISTRAL_API_KEY="your_mistral_key_here"               # Optional, for Mistral AI models.
-XAI_API_KEY="YOUR_XAI_KEY_HERE"                       # Optional, for xAI AI models.
-AZURE_OPENAI_API_KEY="your_azure_key_here"            # Optional, for Azure OpenAI models (requires endpoint in .taskmaster/config.json).
-OLLAMA_API_KEY="your_ollama_api_key_here"             # Optional: For remote Ollama servers that require authentication.
+# ローカル用PostgreSQLコンテナのポート
+DB_PORT=5432

--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_HOST_AUTH_METHOD: md5
     ports:
-      - "5432:5432"
+      - "${DB_PORT}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./database/init:/docker-entrypoint-initdb.d

--- a/docs/task-logs/CHASE-66/api-design-consideration.md
+++ b/docs/task-logs/CHASE-66/api-design-consideration.md
@@ -1,0 +1,612 @@
+# GitHubリポジトリ追加API設計検討（現在の実装準拠版）
+
+## 検討対象
+
+1. DataSource追加APIのインターフェース
+2. GitHub APIを呼び出して情報を取得するサービスクラスの設計
+
+## 現在の実装状況確認
+
+### 既存アーキテクチャ
+
+- **Features-First Approach**: 機能単位でのコロケーション
+- **DataSourceパターン**: `data_sources` ↔ `repositories` 1対1関係
+- **UUIDv7**: アプリケーション側で生成
+- **Hono + @hono/zod-openapi**: OpenAPI統合
+- **レイヤ別責任分離**: domain, services, repositories, presentation
+
+### 既存DBスキーマ
+
+既に以下のテーブルが実装済み：
+
+- `data_sources`: sourceType='github_repository', sourceId='owner/repo'
+- `repositories`: dataSourceId参照, githubId, fullName等
+- `user_watches`: ユーザーの監視設定
+
+## 1. DataSource追加API設計（既存実装準拠）
+
+### フォルダ構成
+
+```
+packages/backend/src/features/data-source/
+├── domain/
+│   ├── data-source.ts          # DataSource型定義
+│   ├── repository.ts           # Repository型定義
+│   ├── user-watch.ts           # UserWatch型定義
+│   └── __tests__/
+├── services/
+│   ├── data-source-creation.service.ts  # DataSource作成サービス
+│   ├── github-api.service.ts             # GitHub API統合サービス
+│   └── __tests__/
+├── repositories/
+│   ├── data-source.repository.ts
+│   ├── repository.repository.ts
+│   ├── user-watch.repository.ts
+│   └── __tests__/
+├── presentation/
+│   ├── routes/
+│   │   └── data-sources/
+│   │       └── index.ts        # エンドポイント実装
+│   ├── schemas/
+│   │   └── data-source.schema.ts  # 共通スキーマ
+│   └── routes.ts
+├── constants/
+│   └── validation.ts           # バリデーション定数
+└── errors/
+    └── github-api.error.ts     # GitHub API関連エラー
+```
+
+### APIエンドポイント設計
+
+#### エンドポイント
+
+```
+POST /api/v1/data-sources
+```
+
+#### バリデーション定数
+
+```typescript
+// constants/validation.ts
+export const GITHUB_OWNER = {
+  MIN_LENGTH: 1,
+  MAX_LENGTH: 39,
+  PATTERN: /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$/,
+  ERROR_MESSAGE: "GitHubユーザー名は1-39文字の英数字とハイフンのみ使用可能です",
+} as const;
+
+export const GITHUB_REPO = {
+  MIN_LENGTH: 1,
+  MAX_LENGTH: 100,
+  PATTERN: /^[a-zA-Z0-9._-]+$/,
+  ERROR_MESSAGE:
+    "リポジトリ名は1-100文字の英数字、ピリオド、ハイフン、アンダースコアのみ使用可能です",
+} as const;
+```
+
+#### リクエスト（Zodスキーマ）
+
+```typescript
+// presentation/routes/data-sources/index.ts
+import { GITHUB_OWNER, GITHUB_REPO } from "../../constants/validation";
+
+// 将来拡張性を考慮したdiscriminatedUnion
+const createDataSourceRequestSchema = z
+  .discriminatedUnion("type", [
+    z.object({
+      type: z.literal("GITHUB_REPOSITORY").openapi({
+        description: "データソースの種類",
+        example: "GITHUB_REPOSITORY",
+      }),
+      owner: z
+        .string()
+        .min(GITHUB_OWNER.MIN_LENGTH)
+        .max(GITHUB_OWNER.MAX_LENGTH)
+        .regex(GITHUB_OWNER.PATTERN, GITHUB_OWNER.ERROR_MESSAGE)
+        .openapi({
+          description: "GitHubリポジトリの所有者",
+          example: "facebook",
+        }),
+      repo: z
+        .string()
+        .min(GITHUB_REPO.MIN_LENGTH)
+        .max(GITHUB_REPO.MAX_LENGTH)
+        .regex(GITHUB_REPO.PATTERN, GITHUB_REPO.ERROR_MESSAGE)
+        .openapi({
+          description: "GitHubリポジトリ名",
+          example: "react",
+        }),
+      monitorReleases: z.boolean().default(true).openapi({
+        description: "リリースの監視を有効にするか",
+      }),
+      monitorPullRequests: z.boolean().default(false).openapi({
+        description: "プルリクエストの監視を有効にするか",
+      }),
+      monitorIssues: z.boolean().default(false).openapi({
+        description: "Issueの監視を有効にするか",
+      }),
+      notificationEnabled: z.boolean().default(true).openapi({
+        description: "通知を有効にするか",
+      }),
+    }),
+    // 将来のNPM対応
+    // z.object({
+    //   type: z.literal('NPM_PACKAGE'),
+    //   packageName: z.string(),
+    //   // NPM固有設定
+    // }),
+  ])
+  .openapi("CreateDataSourceRequest");
+```
+
+#### レスポンス（既存スキーマ準拠）
+
+```typescript
+const dataSourceResponseSchema = z
+  .object({
+    dataSource: z.object({
+      id: z.string().uuid(),
+      sourceType: z.string(),
+      sourceId: z.string(),
+      name: z.string(),
+      description: z.string(),
+      url: z.string(),
+      isPrivate: z.boolean(),
+      createdAt: z.string().datetime(),
+      updatedAt: z.string().datetime(),
+    }),
+    repository: z.object({
+      id: z.string().uuid(),
+      githubId: z.number(),
+      fullName: z.string(),
+      language: z.string().nullable(),
+      starsCount: z.number(),
+      forksCount: z.number(),
+      openIssuesCount: z.number(),
+      isFork: z.boolean(),
+      createdAt: z.string().datetime(),
+      updatedAt: z.string().datetime(),
+    }),
+    userWatch: z.object({
+      watchReleases: z.boolean(),
+      watchIssues: z.boolean(),
+      watchPullRequests: z.boolean(),
+      notificationEnabled: z.boolean(),
+      addedAt: z.string().datetime(),
+    }),
+  })
+  .openapi("CreateDataSourceResponse");
+```
+
+### Domain層設計（TypeScript type）
+
+```typescript
+// domain/data-source.ts
+export type DataSource = {
+  id: string;
+  sourceType: string;
+  sourceId: string;
+  name: string;
+  description: string;
+  url: string;
+  isPrivate: boolean;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+};
+
+// domain/repository.ts
+export type Repository = {
+  id: string;
+  dataSourceId: string;
+  githubId: number;
+  fullName: string;
+  language: string | null;
+  starsCount: number;
+  forksCount: number;
+  openIssuesCount: number;
+  isFork: boolean;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+};
+
+// domain/user-watch.ts
+export type UserWatch = {
+  id: string;
+  userId: string;
+  dataSourceId: string;
+  notificationEnabled: boolean;
+  watchReleases: boolean;
+  watchIssues: boolean;
+  watchPullRequests: boolean;
+  addedAt: Date | null;
+};
+```
+
+### Service層設計（DTO型使用）
+
+```typescript
+// services/data-source-creation.service.ts
+import type { DataSource, Repository, UserWatch } from "../domain";
+
+export type CreateDataSourceInputDto = {
+  userId: string;
+  type: "GITHUB_REPOSITORY";
+  owner: string;
+  repo: string;
+  monitoringSettings: {
+    releases: boolean;
+    pullRequests: boolean;
+    issues: boolean;
+  };
+  notificationEnabled: boolean;
+};
+
+export type CreateDataSourceOutputDto = {
+  dataSource: DataSource;
+  repository: Repository;
+  userWatch: UserWatch;
+};
+
+export class DataSourceCreationService {
+  constructor(
+    private dataSourceRepository: DataSourceRepository,
+    private repositoryRepository: RepositoryRepository,
+    private userWatchRepository: UserWatchRepository,
+    private githubApiService: GitHubApiServiceInterface
+  ) {}
+
+  async createGitHubDataSource(
+    input: CreateDataSourceInputDto
+  ): Promise<CreateDataSourceOutputDto> {
+    // sourceIdを構築（既存DBスキーマとの互換性のため）
+    const sourceId = `${input.owner}/${input.repo}`;
+
+    // 既存データソースの重複チェック
+    const existingDataSource =
+      await this.dataSourceRepository.findBySourceTypeAndId(
+        "github_repository", // 小文字で既存DBスキーマに合わせる
+        sourceId
+      );
+
+    if (existingDataSource) {
+      // 既存の場合はUserWatchのみ追加
+      const userWatch = await this.userWatchRepository.create({
+        userId: input.userId,
+        dataSourceId: existingDataSource.id,
+        watchReleases: input.monitoringSettings.releases,
+        watchIssues: input.monitoringSettings.issues,
+        watchPullRequests: input.monitoringSettings.pullRequests,
+        notificationEnabled: input.notificationEnabled,
+      });
+
+      const repository = await this.repositoryRepository.findByDataSourceId(
+        existingDataSource.id
+      );
+
+      return {
+        dataSource: existingDataSource,
+        repository: repository!,
+        userWatch,
+      };
+    }
+
+    // GitHub APIから情報取得
+    const githubRepo = await this.githubApiService.getRepository(
+      input.owner,
+      input.repo
+    );
+
+    // UUIDv7生成
+    const dataSourceId = generateUuidV7();
+    const repositoryId = generateUuidV7();
+    const userWatchId = generateUuidV7();
+
+    // DataSource作成
+    const dataSource = await this.dataSourceRepository.create({
+      id: dataSourceId,
+      sourceType: "github_repository", // 小文字で既存DBスキーマに合わせる
+      sourceId,
+      name: githubRepo.fullName,
+      description: githubRepo.description,
+      url: `https://github.com/${sourceId}`,
+      isPrivate: githubRepo.isPrivate,
+    });
+
+    // Repository作成
+    const repository = await this.repositoryRepository.create({
+      id: repositoryId,
+      dataSourceId,
+      githubId: githubRepo.githubId,
+      fullName: githubRepo.fullName,
+      language: githubRepo.language,
+      starsCount: githubRepo.starsCount,
+      forksCount: githubRepo.forksCount,
+      openIssuesCount: githubRepo.openIssuesCount,
+      isFork: githubRepo.isFork,
+    });
+
+    // UserWatch作成
+    const userWatch = await this.userWatchRepository.create({
+      id: userWatchId,
+      userId: input.userId,
+      dataSourceId,
+      watchReleases: input.monitoringSettings.releases,
+      watchIssues: input.monitoringSettings.issues,
+      watchPullRequests: input.monitoringSettings.pullRequests,
+      notificationEnabled: input.notificationEnabled,
+    });
+
+    return {
+      dataSource,
+      repository,
+      userWatch,
+    };
+  }
+}
+```
+
+## 2. GitHub APIサービス設計
+
+### エラークラス実装
+
+```typescript
+// errors/github-api.error.ts
+export class GitHubApiParseError extends Error {
+  constructor(
+    message: string,
+    public readonly originalError: Error | unknown | null = null,
+    public readonly rawData: unknown = null
+  ) {
+    super(message);
+    this.name = "GitHubApiParseError";
+  }
+
+  getDebugInfo(): {
+    message: string;
+    originalError?: string;
+    rawDataType: string;
+    rawDataSample?: string;
+  } {
+    return {
+      message: this.message,
+      originalError:
+        this.originalError instanceof Error
+          ? this.originalError.message
+          : String(this.originalError),
+      rawDataType: typeof this.rawData,
+      rawDataSample: this.rawData
+        ? JSON.stringify(this.rawData).substring(0, 200) + "..."
+        : undefined,
+    };
+  }
+}
+
+export class GitHubApiError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+    public readonly response?: unknown
+  ) {
+    super(message);
+    this.name = "GitHubApiError";
+  }
+}
+```
+
+### GitHub APIサービス実装（Octokit使用）
+
+```typescript
+// services/github-api-service.interface.ts
+export interface GitHubApiServiceInterface {
+  getRepository(owner: string, repo: string): Promise<GitHubRepositoryDto>;
+  validateRepository(owner: string, repo: string): Promise<boolean>;
+}
+
+export type GitHubRepositoryDto = {
+  githubId: number;
+  fullName: string;
+  description: string;
+  starsCount: number;
+  forksCount: number;
+  watchersCount: number;
+  openIssuesCount: number;
+  language: string | null;
+  homepage: string | null;
+  isFork: boolean;
+  isPrivate: boolean;
+};
+```
+
+```typescript
+// services/github-api.service.ts
+import { Octokit } from "@octokit/rest";
+import { z } from "zod";
+import {
+  GitHubApiError,
+  GitHubApiParseError,
+} from "../errors/github-api.error";
+import type {
+  GitHubApiServiceInterface,
+  GitHubRepositoryDto,
+} from "./github-api-service.interface";
+
+// GitHub APIレスポンスをパースするためのZodスキーマ
+const githubRepositoryApiSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  full_name: z.string(),
+  description: z.string().nullable(),
+  stargazers_count: z.number(),
+  forks_count: z.number(),
+  watchers_count: z.number(),
+  open_issues_count: z.number(),
+  language: z.string().nullable(),
+  homepage: z.string().nullable(),
+  fork: z.boolean(),
+  private: z.boolean(),
+  owner: z.object({
+    login: z.string(),
+  }),
+});
+
+type GitHubRepositoryApiResponse = z.infer<typeof githubRepositoryApiSchema>;
+
+export class GitHubApiService implements GitHubApiServiceInterface {
+  private octokit: Octokit;
+
+  constructor(accessToken?: string) {
+    this.octokit = new Octokit({
+      auth: accessToken, // undefined for public repos
+    });
+  }
+
+  async getRepository(
+    owner: string,
+    repo: string
+  ): Promise<GitHubRepositoryDto> {
+    try {
+      const response = await this.octokit.repos.get({ owner, repo });
+
+      // Zodでレスポンスを安全にパース・検証（Parser処理をサービス内で実行）
+      const parsedData = githubRepositoryApiSchema.parse(response.data);
+
+      return this.mapToDto(parsedData);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new GitHubApiParseError(
+          "GitHub repository APIレスポンスのパースに失敗しました",
+          error,
+          error.errors
+        );
+      }
+
+      // プロジェクト固有のエラーにラップしてスロー
+      throw new GitHubApiError(
+        `Repository not found: ${owner}/${repo}`,
+        error.status,
+        error.response?.data
+      );
+    }
+  }
+
+  async validateRepository(owner: string, repo: string): Promise<boolean> {
+    try {
+      await this.getRepository(owner, repo);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private mapToDto(data: GitHubRepositoryApiResponse): GitHubRepositoryDto {
+    return {
+      githubId: data.id,
+      fullName: data.full_name,
+      description: data.description || "",
+      starsCount: data.stargazers_count,
+      forksCount: data.forks_count,
+      watchersCount: data.watchers_count,
+      openIssuesCount: data.open_issues_count,
+      language: data.language,
+      homepage: data.homepage,
+      isFork: data.fork,
+      isPrivate: data.private,
+    };
+  }
+}
+```
+
+### テスト用スタブ実装
+
+```typescript
+// services/__tests__/github-api.service.stub.ts
+import type {
+  GitHubApiServiceInterface,
+  GitHubRepositoryDto,
+} from "../github-api-service.interface";
+import { GitHubApiError } from "../../errors/github-api.error";
+
+export class GitHubApiServiceStub implements GitHubApiServiceInterface {
+  private repositories: Map<string, GitHubRepositoryDto> = new Map();
+
+  setRepository(
+    owner: string,
+    repo: string,
+    repository: GitHubRepositoryDto
+  ): void {
+    this.repositories.set(`${owner}/${repo}`, repository);
+  }
+
+  async getRepository(
+    owner: string,
+    repo: string
+  ): Promise<GitHubRepositoryDto> {
+    const key = `${owner}/${repo}`;
+    const repository = this.repositories.get(key);
+    if (!repository) {
+      throw new GitHubApiError(`Repository not found: ${key}`, 404);
+    }
+    return repository;
+  }
+
+  async validateRepository(owner: string, repo: string): Promise<boolean> {
+    return this.repositories.has(`${owner}/${repo}`);
+  }
+}
+```
+
+## 3. 依存性注入とサービス統合
+
+```typescript
+// services/index.ts
+import { DataSourceRepository } from "../repositories/data-source.repository";
+import { RepositoryRepository } from "../repositories/repository.repository";
+import { UserWatchRepository } from "../repositories/user-watch.repository";
+import { DataSourceCreationService } from "./data-source-creation.service";
+import { GitHubApiService } from "./github-api.service";
+
+// 依存性注入によるサービス初期化
+export const githubApiService = new GitHubApiService(
+  process.env.GITHUB_ACCESS_TOKEN // 環境変数から取得、undefined for public repos
+);
+
+export const dataSourceCreationService = new DataSourceCreationService(
+  new DataSourceRepository(),
+  new RepositoryRepository(),
+  new UserWatchRepository(),
+  githubApiService
+);
+
+// テスト用ファクトリ関数
+export const createDataSourceCreationService = (
+  githubService: GitHubApiServiceInterface
+) =>
+  new DataSourceCreationService(
+    new DataSourceRepository(),
+    new RepositoryRepository(),
+    new UserWatchRepository(),
+    githubService
+  );
+```
+
+## 4. 認証方式とセキュリティ
+
+### GitHub App方式（推奨）
+
+- アプリケーション固有の短命アクセストークン
+- レート制限が高い（5,000 requests/hour）
+- プライベートリポジトリ対応可能
+- Auth0との統合が必要
+
+### 実装優先度
+
+1. **Phase 1**: パブリックリポジトリのみ（認証なし）
+2. **Phase 2**: GitHub App統合
+3. **Phase 3**: Auth0連携
+
+## 次のステップ
+
+1. **即座に実装可能**: パブリックリポジトリ対応API
+2. **中期**: GitHub App設定とAuth0統合
+3. **長期**: プライベートリポジトリ対応
+4. **テスト**: 各レイヤのユニットテスト実装

--- a/packages/backend/drizzle.config.ts
+++ b/packages/backend/drizzle.config.ts
@@ -1,13 +1,5 @@
 import { defineConfig } from "drizzle-kit"
-import { config } from "dotenv"
 import process from "node:process"
-
-// 環境に応じて適切な.envファイルを選択
-const envFile = process.env.NODE_ENV === "test" ? ".env.testing" : ".env"
-config({ path: envFile })
-
-console.log(`🔧 Drizzle config loading: ${envFile}`)
-
 export default defineConfig({
   dialect: "postgresql",
   schema: "./src/db/schema.ts",

--- a/packages/backend/scripts/test-migrate.js
+++ b/packages/backend/scripts/test-migrate.js
@@ -7,6 +7,11 @@
  */
 
 import { spawn } from "node:child_process"
+import { config } from "dotenv"
+// 環境に応じて適切な.envファイルを選択
+config({ path: '.env.testing' })
+
+console.log(`🔧 Drizzle config loading: .env.testing`)
 
 console.log("🧪 Running test database migration...")
 

--- a/packages/backend/src/db/migrations/0002_absent_tempest.sql
+++ b/packages/backend/src/db/migrations/0002_absent_tempest.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "user_watches" DROP COLUMN "watch_pushes";--> statement-breakpoint
+ALTER TABLE "user_watches" DROP COLUMN "watch_security_alerts";

--- a/packages/backend/src/db/migrations/meta/0002_snapshot.json
+++ b/packages/backend/src/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1662 @@
+{
+  "id": "020c97c4-4a6f-45fe-91fb-3266ec16b801",
+  "prevId": "626c5aa8-7041-4816-adc8-348efe4b0569",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bookmark_type": {
+          "name": "bookmark_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_bookmark_target_unique": {
+          "name": "bookmarks_user_bookmark_target_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bookmark_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookmarks_user_id": {
+          "name": "idx_bookmarks_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookmarks_target_id": {
+          "name": "idx_bookmarks_target_id",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookmarks_type_target": {
+          "name": "idx_bookmarks_type_target",
+          "columns": [
+            {
+              "expression": "bookmark_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookmarks_user_type": {
+          "name": "idx_bookmarks_user_type",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bookmark_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookmarks_created_at": {
+          "name": "idx_bookmarks_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_sources": {
+      "name": "data_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_sources_source_type_source_id_unique": {
+          "name": "data_sources_source_type_source_id_unique",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_data_sources_type": {
+          "name": "idx_data_sources_type",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_data_sources_source_id": {
+          "name": "idx_data_sources_source_id",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_data_sources_name": {
+          "name": "idx_data_sources_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_data_sources_created_at": {
+          "name": "idx_data_sources_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_data_sources_updated_at": {
+          "name": "idx_data_sources_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_event_id": {
+          "name": "github_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_data_source_github_event_type_unique": {
+          "name": "events_data_source_github_event_type_unique",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_data_source_id": {
+          "name": "idx_events_data_source_id",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_type": {
+          "name": "idx_events_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_title": {
+          "name": "idx_events_title",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_version": {
+          "name": "idx_events_version",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_github_event_id": {
+          "name": "idx_events_github_event_id",
+          "columns": [
+            {
+              "expression": "github_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_data_source_type": {
+          "name": "idx_events_data_source_type",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_data_source_created": {
+          "name": "idx_events_data_source_created",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_created_at": {
+          "name": "idx_events_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_updated_at": {
+          "name": "idx_events_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_data_source_id_data_sources_id_fk": {
+          "name": "events_data_source_id_data_sources_id_fk",
+          "tableFrom": "events",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id": {
+          "name": "idx_notifications_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_event_id": {
+          "name": "idx_notifications_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_is_read": {
+          "name": "idx_notifications_is_read",
+          "columns": [
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_notification_type": {
+          "name": "idx_notifications_notification_type",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_read": {
+          "name": "idx_notifications_user_read",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_created": {
+          "name": "idx_notifications_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_sent_at": {
+          "name": "idx_notifications_sent_at",
+          "columns": [
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_created_at": {
+          "name": "idx_notifications_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_updated_at": {
+          "name": "idx_notifications_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_event_id_events_id_fk": {
+          "name": "notifications_event_id_events_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stars_count": {
+          "name": "stars_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forks_count": {
+          "name": "forks_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "open_issues_count": {
+          "name": "open_issues_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_fork": {
+          "name": "is_fork",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_repositories_data_source_id": {
+          "name": "idx_repositories_data_source_id",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repositories_github_id": {
+          "name": "idx_repositories_github_id",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repositories_full_name": {
+          "name": "idx_repositories_full_name",
+          "columns": [
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repositories_language": {
+          "name": "idx_repositories_language",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repositories_stars_count": {
+          "name": "idx_repositories_stars_count",
+          "columns": [
+            {
+              "expression": "stars_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repositories_created_at": {
+          "name": "idx_repositories_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repositories_updated_at": {
+          "name": "idx_repositories_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repositories_data_source_id_data_sources_id_fk": {
+          "name": "repositories_data_source_id_data_sources_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repositories_github_id_unique": {
+          "name": "repositories_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "logged_in_at": {
+          "name": "logged_in_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_email": {
+          "name": "idx_sessions_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_preferences_user_id": {
+          "name": "idx_user_preferences_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_preferences_created_at": {
+          "name": "idx_user_preferences_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_preferences_updated_at": {
+          "name": "idx_user_preferences_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_watches": {
+      "name": "user_watches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_enabled": {
+          "name": "notification_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watch_releases": {
+          "name": "watch_releases",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watch_issues": {
+          "name": "watch_issues",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watch_pull_requests": {
+          "name": "watch_pull_requests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_watches_user_id_data_source_id_unique": {
+          "name": "user_watches_user_id_data_source_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_watches_user_id": {
+          "name": "idx_user_watches_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_watches_data_source_id": {
+          "name": "idx_user_watches_data_source_id",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_watches_added_at": {
+          "name": "idx_user_watches_added_at",
+          "columns": [
+            {
+              "expression": "added_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_watches_user_id_users_id_fk": {
+          "name": "user_watches_user_id_users_id_fk",
+          "tableFrom": "user_watches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_watches_data_source_id_data_sources_id_fk": {
+          "name": "user_watches_data_source_id_data_sources_id_fk",
+          "tableFrom": "user_watches",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "auth0_user_id": {
+          "name": "auth0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_auth0_user_id": {
+          "name": "idx_users_auth0_user_id",
+          "columns": [
+            {
+              "expression": "auth0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_github_username": {
+          "name": "idx_users_github_username",
+          "columns": [
+            {
+              "expression": "github_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_created_at": {
+          "name": "idx_users_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_updated_at": {
+          "name": "idx_users_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth0_user_id_unique": {
+          "name": "users_auth0_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth0_user_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/backend/src/db/migrations/meta/_journal.json
+++ b/packages/backend/src/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1750331900193,
       "tag": "0001_fixed_paladin",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1751978422605,
+      "tag": "0002_absent_tempest",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/src/db/schema.ts
+++ b/packages/backend/src/db/schema.ts
@@ -109,8 +109,6 @@ export const userWatches = pgTable(
     watchReleases: boolean("watch_releases").notNull(),
     watchIssues: boolean("watch_issues").notNull(),
     watchPullRequests: boolean("watch_pull_requests").notNull(),
-    watchPushes: boolean("watch_pushes").notNull(),
-    watchSecurityAlerts: boolean("watch_security_alerts").notNull(),
     addedAt: timestamp("added_at", { withTimezone: true }).defaultNow(),
   },
   (table) => ({


### PR DESCRIPTION
## Summary
CHASE-66タスクにおけるGitHubリポジトリ追加APIの詳細設計検討を完了しました。

## 実装された設計のポイント

### 🎯 既存実装準拠
- Features-First Approach維持
- 既存DBスキーマ（data_sources, repositories, user_watches）との完全互換性
- UUIDv7生成パターンの継続
- Hono + @hono/zod-openapi統合

### 🚀 API設計の改善
- **直感的な入力**: owner/repo分離（`sourceId: 'owner/repo'`から改善）
- **明確な命名**: monitor*命名（watch*より意味が明確）
- **将来拡張性**: discriminatedUnionによるNPM対応準備
- **バリデーション強化**: 定数管理とOpenAPI仕様の充実

### 🏗️ アーキテクチャの簡素化
- **parsersフォルダ削除**: Parser処理をサービス内に統合
- **インターフェース名変更**: GitHubRepositoryService → GitHubApiServiceInterface
- **UserWatch簡素化**: 不要なwatchSecurityAlerts, watchPushes削除

### 🔧 実装志向設計
- **Octokitライブラリ採用**: 実際の開発で使用される標準ライブラリ
- **段階的認証実装**: パブリック→GitHub App→Auth0連携
- **テスト可能性**: 依存性注入とスタブ実装

## Test plan
- [ ] 設計ドキュメントのレビュー
- [ ] 後続実装タスクでの活用確認

🤖 Generated with [Claude Code](https://claude.ai/code)