### PR TITLE
feat(CHASE-56): DataSourceCreationServiceのComponentテストでモックを廃止し実DBアクセスに変更

### DIFF
--- a/packages/backend/.env.testing
+++ b/packages/backend/.env.testing
@@ -31,6 +31,7 @@ AUTH0_AUDIENCE=test-audience
 # ==============================================
 # テスト用のダミートークン（実際のAPIは呼ばない）
 GITHUB_TOKEN=test_token_dummy
+USE_GITHUB_API_STUB=true
 
 # ==============================================
 # その他テスト設定

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -4,6 +4,8 @@ import { logger } from "hono/logger"
 import { Scalar } from "@scalar/hono-api-reference"
 import { globalJWTAuth, createAuthRoutes } from "./features/auth"
 import userRoutes from "./features/user/presentation"
+import dataSourceRoutes from "./features/data-sources"
+import { createE2EControlRoutes } from "./features/data-sources/presentation/routes/e2e-control"
 
 /**
  * Chase Light Backend Application
@@ -36,26 +38,28 @@ export const createApp = () => {
     }),
   )
 
-  // GitHub API サービス初期化（環境変数から）
-  const githubToken = process.env.GITHUB_TOKEN
-  if (!githubToken) {
-    throw new Error("GITHUB_TOKEN environment variable is required")
-  }
-
   // Auth API routes
   app.route("/api/auth", createAuthRoutes())
 
   // User management API routes
   app.route("/api/users", userRoutes)
 
+  // Data Source management API routes
+  app.route("/api", dataSourceRoutes)
+
+  // E2E Control API routes (only in stub mode)
+  if (process.env.USE_GITHUB_API_STUB === "true") {
+    app.route("/api", createE2EControlRoutes())
+  }
+
   // OpenAPI仕様書エンドポイント
   app.doc("/doc", {
     openapi: "3.0.0",
     info: {
       version: "1.0.0",
-      title: "Chase Light Data Source API",
+      title: "Chase Light API",
       description:
-        "GitHub リポジトリデータ取得API - TypeScript + Hono + Zod + OpenAPI",
+        "GitHub リポジトリ監視サービス API - TypeScript + Hono + Zod + OpenAPI",
     },
     servers: [
       {

--- a/packages/backend/src/features/auth/middleware/auth-exclusions.ts
+++ b/packages/backend/src/features/auth/middleware/auth-exclusions.ts
@@ -25,6 +25,9 @@ export const DEFAULT_AUTH_EXCLUSIONS: AuthExclusionConfig = {
   ],
   pathPrefixes: [
     "/api/public/", // パブリックAPI
+    ...(process.env.USE_GITHUB_API_STUB === "true"
+      ? ["/api/e2e-control/"]
+      : []), // E2E制御API（スタブモード時のみ）
   ],
   patterns: [
     /^\/static\/.*/, // 静的ファイル

--- a/packages/backend/src/features/data-sources/domain/data-source.ts
+++ b/packages/backend/src/features/data-sources/domain/data-source.ts
@@ -1,0 +1,38 @@
+/**
+ * データソースのドメイン型定義
+ * GitHubリポジトリやNPMパッケージなど、各種データソースを抽象化した型
+ */
+export type DataSource = {
+  id: string
+  sourceType: string
+  sourceId: string
+  name: string
+  description: string
+  url: string
+  isPrivate: boolean
+  createdAt: Date
+  updatedAt: Date
+}
+
+/**
+ * データソース作成時の入力型
+ */
+export type DataSourceCreationInput = {
+  sourceType: string
+  sourceId: string
+  name: string
+  description: string
+  url: string
+  isPrivate: boolean
+}
+
+/**
+ * データソースのソースタイプ定数
+ */
+export const DATA_SOURCE_TYPES = {
+  GITHUB: "github",
+  NPM: "npm", // 将来対応予定
+} as const
+
+export type DataSourceType =
+  (typeof DATA_SOURCE_TYPES)[keyof typeof DATA_SOURCE_TYPES]

--- a/packages/backend/src/features/data-sources/domain/index.ts
+++ b/packages/backend/src/features/data-sources/domain/index.ts
@@ -1,0 +1,4 @@
+// データソースドメインのエクスポート
+export * from "./data-source"
+export * from "./repository"
+export * from "./user-watch"

--- a/packages/backend/src/features/data-sources/domain/repository.ts
+++ b/packages/backend/src/features/data-sources/domain/repository.ts
@@ -1,0 +1,31 @@
+/**
+ * GitHubリポジトリのドメイン型定義
+ * データソースと1対1の関係を持つ
+ */
+export type Repository = {
+  id: string
+  dataSourceId: string
+  githubId: number
+  fullName: string
+  language: string | null
+  starsCount: number
+  forksCount: number
+  openIssuesCount: number
+  isFork: boolean
+  createdAt: Date
+  updatedAt: Date
+}
+
+/**
+ * リポジトリ作成時の入力型
+ */
+export type RepositoryCreationInput = {
+  dataSourceId: string
+  githubId: number
+  fullName: string
+  language: string | null
+  starsCount: number
+  forksCount: number
+  openIssuesCount: number
+  isFork: boolean
+}

--- a/packages/backend/src/features/data-sources/domain/user-watch.ts
+++ b/packages/backend/src/features/data-sources/domain/user-watch.ts
@@ -1,0 +1,26 @@
+/**
+ * ユーザーウォッチのドメイン型定義
+ * ユーザーがデータソースを監視する設定を表現
+ */
+export type UserWatch = {
+  id: string
+  userId: string
+  dataSourceId: string
+  notificationEnabled: boolean
+  watchReleases: boolean
+  watchIssues: boolean
+  watchPullRequests: boolean
+  addedAt: Date
+}
+
+/**
+ * ユーザーウォッチ作成時の入力型
+ */
+export type UserWatchCreationInput = {
+  userId: string
+  dataSourceId: string
+  notificationEnabled: boolean
+  watchReleases: boolean
+  watchIssues: boolean
+  watchPullRequests: boolean
+}

--- a/packages/backend/src/features/data-sources/errors/duplicate-data-source.error.ts
+++ b/packages/backend/src/features/data-sources/errors/duplicate-data-source.error.ts
@@ -1,0 +1,9 @@
+/**
+ * データソース作成の重複エラー
+ */
+export class DuplicateDataSourceError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "DuplicateDataSourceError"
+  }
+}

--- a/packages/backend/src/features/data-sources/errors/github-api.error.ts
+++ b/packages/backend/src/features/data-sources/errors/github-api.error.ts
@@ -1,0 +1,12 @@
+/**
+ * GitHub API エラーの型定義
+ */
+export class GitHubApiError extends Error {
+  constructor(
+    message: string,
+    public status?: number,
+  ) {
+    super(message)
+    this.name = "GitHubApiError"
+  }
+}

--- a/packages/backend/src/features/data-sources/errors/index.ts
+++ b/packages/backend/src/features/data-sources/errors/index.ts
@@ -1,2 +1,4 @@
 export { GitHubApiError } from "./github-api.error"
 export { DuplicateDataSourceError } from "./duplicate-data-source.error"
+export { UserNotFoundError } from "./user-not-found.error"
+export { InvalidRepositoryUrlError } from "./invalid-repository-url.error"

--- a/packages/backend/src/features/data-sources/errors/index.ts
+++ b/packages/backend/src/features/data-sources/errors/index.ts
@@ -1,0 +1,2 @@
+export { GitHubApiError } from "./github-api.error"
+export { DuplicateDataSourceError } from "./duplicate-data-source.error"

--- a/packages/backend/src/features/data-sources/errors/invalid-repository-url.error.ts
+++ b/packages/backend/src/features/data-sources/errors/invalid-repository-url.error.ts
@@ -1,0 +1,13 @@
+/**
+ * 無効なリポジトリURLの場合のエラー
+ */
+export class InvalidRepositoryUrlError extends Error {
+  constructor(url?: string) {
+    super(
+      url
+        ? `Invalid GitHub repository URL format: ${url}`
+        : "Invalid GitHub repository URL format",
+    )
+    this.name = "InvalidRepositoryUrlError"
+  }
+}

--- a/packages/backend/src/features/data-sources/errors/user-not-found.error.ts
+++ b/packages/backend/src/features/data-sources/errors/user-not-found.error.ts
@@ -1,0 +1,9 @@
+/**
+ * ユーザーが見つからない場合のエラー
+ */
+export class UserNotFoundError extends Error {
+  constructor(auth0UserId: string) {
+    super(`User not found for auth0UserId: ${auth0UserId}`)
+    this.name = "UserNotFoundError"
+  }
+}

--- a/packages/backend/src/features/data-sources/index.ts
+++ b/packages/backend/src/features/data-sources/index.ts
@@ -1,0 +1,44 @@
+import {
+  DataSourceRepository,
+  RepositoryRepository,
+  UserWatchRepository,
+} from "./repositories"
+import { UserRepository } from "../user/repositories/user.repository"
+import { DataSourceCreationService } from "./services"
+import { createDataSourcePresentationRoutes } from "./presentation"
+
+/**
+ * Data Sources Presentation Layer Entry Point
+ * データソース管理API プレゼンテーション層のエントリーポイント
+ *
+ * 依存性注入によりサービス層との結合を行う
+ */
+
+// リポジトリのインスタンス作成
+const dataSourceRepository = new DataSourceRepository()
+const repositoryRepository = new RepositoryRepository()
+const userWatchRepository = new UserWatchRepository()
+const userRepository = new UserRepository()
+
+// サービスの依存性注入
+const dataSourceCreationService = new DataSourceCreationService(
+  dataSourceRepository,
+  repositoryRepository,
+  userWatchRepository,
+  userRepository,
+)
+
+// 依存性を注入してルーターを構築
+const dataSourceRoutes = createDataSourcePresentationRoutes(
+  dataSourceCreationService,
+)
+
+export default dataSourceRoutes
+
+// ファクトリー関数もエクスポート（テスト用）
+export { createDataSourcePresentationRoutes } from "./presentation"
+
+// ドメイン型とエラークラスをエクスポート
+export * from "./domain"
+export * from "./services"
+export * from "./presentation/shared/error-handling"

--- a/packages/backend/src/features/data-sources/presentation/helpers/github-stub.helper.ts
+++ b/packages/backend/src/features/data-sources/presentation/helpers/github-stub.helper.ts
@@ -1,0 +1,150 @@
+// @playwright/testはE2Eテスト実行時のみ利用可能
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Page = any
+import type { GitHubRepositoryResponse } from "../../services/interfaces/github-api-service.interface"
+
+/**
+ * Playwright用GitHubスタブヘルパー
+ * E2Eテストでのスタブ制御を簡易化
+ */
+export class GitHubStubHelper {
+  constructor(
+    private page: Page,
+    private baseUrl: string = "http://localhost:3000",
+  ) {}
+
+  /**
+   * 特定のリポジトリにスタブレスポンスを設定
+   */
+  async setStubResponse(
+    key: string,
+    response: GitHubRepositoryResponse,
+  ): Promise<void> {
+    const result = await this.page.request.post(
+      `${this.baseUrl}/e2e-control/github/stub-response`,
+      {
+        data: {
+          key,
+          response,
+        },
+      },
+    )
+
+    if (!result.ok()) {
+      const errorText = await result.text()
+      throw new Error(`Failed to set stub response: ${errorText}`)
+    }
+  }
+
+  /**
+   * 特定のリポジトリにエラーシナリオを設定
+   */
+  async setErrorScenario(
+    key: string,
+    error: { status: number; message: string },
+  ): Promise<void> {
+    const result = await this.page.request.post(
+      `${this.baseUrl}/e2e-control/github/error-scenario`,
+      {
+        data: {
+          key,
+          error,
+        },
+      },
+    )
+
+    if (!result.ok()) {
+      const errorText = await result.text()
+      throw new Error(`Failed to set error scenario: ${errorText}`)
+    }
+  }
+
+  /**
+   * すべてのスタブ設定をリセット
+   */
+  async resetStubs(): Promise<void> {
+    const result = await this.page.request.post(
+      `${this.baseUrl}/e2e-control/github/reset`,
+    )
+
+    if (!result.ok()) {
+      const errorText = await result.text()
+      throw new Error(`Failed to reset stubs: ${errorText}`)
+    }
+  }
+
+  /**
+   * テスト用のリポジトリレスポンスを生成
+   */
+  createTestRepository(params: {
+    owner: string
+    repo: string
+    id?: number
+    language?: string
+    private?: boolean
+    stars?: number
+    forks?: number
+    issues?: number
+  }): GitHubRepositoryResponse {
+    return {
+      id: params.id ?? Math.floor(Math.random() * 1000000) + 1000000,
+      full_name: `${params.owner}/${params.repo}`,
+      name: params.repo,
+      description: `Test repository for ${params.repo}`,
+      html_url: `https://github.com/${params.owner}/${params.repo}`,
+      private: params.private ?? false,
+      language: params.language ?? "JavaScript",
+      stargazers_count: params.stars ?? 1000,
+      forks_count: params.forks ?? 100,
+      open_issues_count: params.issues ?? 10,
+      fork: false,
+    }
+  }
+
+  /**
+   * 複数のリポジトリのスタブを一括設定
+   */
+  async setupMultipleRepositories(
+    repositories: Array<{
+      owner: string
+      repo: string
+      response?: {
+        id?: number
+        language?: string
+        private?: boolean
+        stars?: number
+        forks?: number
+        issues?: number
+      }
+      error?: { status: number; message: string }
+    }>,
+  ): Promise<void> {
+    for (const repo of repositories) {
+      const key = `${repo.owner}/${repo.repo}`
+
+      if (repo.error) {
+        await this.setErrorScenario(key, repo.error)
+      } else {
+        const response = this.createTestRepository({
+          owner: repo.owner,
+          repo: repo.repo,
+          ...(repo.response || {}),
+        })
+        await this.setStubResponse(key, response)
+      }
+    }
+  }
+
+  /**
+   * よく使用されるエラーシナリオの定数
+   */
+  static readonly ERROR_SCENARIOS = {
+    REPOSITORY_NOT_FOUND: { status: 404, message: "Repository not found" },
+    RATE_LIMIT_EXCEEDED: {
+      status: 403,
+      message: "GitHub API rate limit exceeded",
+    },
+    FORBIDDEN: { status: 403, message: "Repository access forbidden" },
+    INTERNAL_ERROR: { status: 500, message: "GitHub API internal error" },
+  } as const
+}

--- a/packages/backend/src/features/data-sources/presentation/index.ts
+++ b/packages/backend/src/features/data-sources/presentation/index.ts
@@ -1,0 +1,4 @@
+// データソースプレゼンテーション層のエクスポート
+export * from "./routes"
+export * from "./schemas"
+export * from "./shared/error-handling"

--- a/packages/backend/src/features/data-sources/presentation/routes.ts
+++ b/packages/backend/src/features/data-sources/presentation/routes.ts
@@ -1,0 +1,17 @@
+import { OpenAPIHono } from "@hono/zod-openapi"
+import type { DataSourceCreationService } from "../services"
+import { createDataSourceRoutes } from "./routes/data-sources"
+
+/**
+ * データソース機能のメインルートファクトリー
+ */
+export function createDataSourcePresentationRoutes(
+  dataSourceCreationService: DataSourceCreationService,
+) {
+  const app = new OpenAPIHono()
+
+  // /data-sources 配下のルートを登録
+  app.route("/data-sources", createDataSourceRoutes(dataSourceCreationService))
+
+  return app
+}

--- a/packages/backend/src/features/data-sources/presentation/routes/data-sources/__tests__/index.test.ts
+++ b/packages/backend/src/features/data-sources/presentation/routes/data-sources/__tests__/index.test.ts
@@ -1,0 +1,289 @@
+import { describe, test, expect, beforeEach } from "vitest"
+import { OpenAPIHono } from "@hono/zod-openapi"
+import { createDataSourceRoutes } from "../index"
+import { DataSourceCreationService } from "../../../../services"
+import {
+  DataSourceRepository,
+  RepositoryRepository,
+  UserWatchRepository,
+} from "../../../../repositories"
+import { UserRepository } from "../../../../../user/repositories/user.repository"
+import { GitHubApiServiceStub } from "../../../../services/github-api-service.stub"
+import type { GitHubRepositoryResponse } from "../../../../services/interfaces/github-api-service.interface"
+import { setupComponentTest, TestDataFactory } from "../../../../../../test"
+import { AuthTestHelper } from "../../../../../auth/test-helpers/auth-test-helper"
+import { globalJWTAuth } from "../../../../../auth"
+import type { User } from "../../../../../user/domain/user"
+
+// Component Test: 実DBを使用してHTTPエンドポイントをテスト
+
+describe("POST /data-sources - Component Test", () => {
+  setupComponentTest()
+
+  let app: OpenAPIHono
+  let dataSourceCreationService: DataSourceCreationService
+  let githubStub: GitHubApiServiceStub
+  let testUser: User
+  let testToken: string
+
+  beforeEach(async () => {
+    // テストユーザーの認証設定をクリア
+    AuthTestHelper.clearTestUsers()
+
+    // テストユーザーをDBに作成
+    testUser = await TestDataFactory.createTestUser("auth0|test123")
+
+    // テスト用トークンを生成
+    testToken = AuthTestHelper.createTestToken(
+      testUser.auth0UserId,
+      testUser.email,
+      testUser.name,
+    )
+
+    // GitHubスタブを作成
+    githubStub = new GitHubApiServiceStub()
+
+    // 実際のリポジトリとサービスを作成（スタブを注入）
+    const dataSourceRepository = new DataSourceRepository()
+    const repositoryRepository = new RepositoryRepository()
+    const userWatchRepository = new UserWatchRepository()
+    const userRepository = new UserRepository()
+    dataSourceCreationService = new DataSourceCreationService(
+      dataSourceRepository,
+      repositoryRepository,
+      userWatchRepository,
+      userRepository,
+      githubStub,
+    )
+
+    // ルートアプリケーション作成
+    app = new OpenAPIHono()
+
+    // 認証ミドルウェアを追加
+    app.use("*", globalJWTAuth)
+
+    // データソースルートを追加
+    const dataSourceRoutes = createDataSourceRoutes(dataSourceCreationService)
+    app.route("/", dataSourceRoutes)
+  })
+
+  describe("正常系", () => {
+    test("有効なリクエストでデータソースが作成される", async () => {
+      const requestBody = {
+        repositoryUrl: "https://github.com/facebook/react",
+        name: "React",
+        description: "A JavaScript library",
+        notificationEnabled: true,
+        watchReleases: true,
+        watchIssues: false,
+        watchPullRequests: false,
+      }
+
+      // GitHubスタブレスポンスを設定
+      const githubResponse: GitHubRepositoryResponse = {
+        id: 10270250,
+        full_name: "facebook/react",
+        name: "react",
+        description:
+          "A declarative, efficient, and flexible JavaScript library for building user interfaces.",
+        html_url: "https://github.com/facebook/react",
+        private: false,
+        language: "JavaScript",
+        stargazers_count: 230000,
+        forks_count: 47000,
+        open_issues_count: 1500,
+        fork: false,
+      }
+      githubStub.setStubResponse("facebook/react", githubResponse)
+
+      const res = await app.request("/", {
+        method: "POST",
+        headers: {
+          ...AuthTestHelper.createAuthHeaders(testToken),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+      })
+
+      expect(res.status).toBe(201)
+
+      const responseBody = await res.json()
+      expect(responseBody.success).toBe(true)
+      expect(responseBody.data.dataSource.name).toBe("React")
+      expect(responseBody.data.dataSource.sourceId).toBe("10270250")
+      expect(responseBody.data.dataSource.url).toBe(
+        "https://github.com/facebook/react",
+      )
+      expect(responseBody.data.repository.fullName).toBe("facebook/react")
+      expect(responseBody.data.repository.githubId).toBe(10270250)
+      expect(responseBody.data.repository.language).toBe("JavaScript")
+      expect(responseBody.data.repository.starsCount).toBe(230000)
+      expect(responseBody.data.userWatch.userId).toBe(testUser.id)
+      expect(responseBody.data.userWatch.notificationEnabled).toBe(true)
+      expect(responseBody.data.userWatch.watchReleases).toBe(true)
+      expect(responseBody.data.userWatch.watchIssues).toBe(false)
+      expect(responseBody.data.userWatch.watchPullRequests).toBe(false)
+    })
+
+    test("最小限のリクエストでもデータソースが作成される", async () => {
+      const requestBody = {
+        repositoryUrl: "https://github.com/microsoft/typescript",
+      }
+
+      // GitHubスタブレスポンスを設定
+      const githubResponse: GitHubRepositoryResponse = {
+        id: 1234567,
+        full_name: "microsoft/typescript",
+        name: "TypeScript",
+        description:
+          "TypeScript is a superset of JavaScript that compiles to plain JavaScript.",
+        html_url: "https://github.com/microsoft/typescript",
+        private: false,
+        language: "TypeScript",
+        stargazers_count: 100000,
+        forks_count: 12000,
+        open_issues_count: 500,
+        fork: false,
+      }
+      githubStub.setStubResponse("microsoft/typescript", githubResponse)
+
+      const res = await app.request("/", {
+        method: "POST",
+        headers: {
+          ...AuthTestHelper.createAuthHeaders(testToken),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+      })
+
+      expect(res.status).toBe(201)
+
+      const responseBody = await res.json()
+      expect(responseBody.success).toBe(true)
+
+      // nameが指定されていない場合、GitHubのnameが使用されることを確認
+      expect(responseBody.data.dataSource.name).toBe("TypeScript")
+      expect(responseBody.data.dataSource.sourceId).toBe("1234567")
+      expect(responseBody.data.repository.fullName).toBe("microsoft/typescript")
+      expect(responseBody.data.repository.language).toBe("TypeScript")
+
+      // デフォルト値での作成を確認
+      expect(responseBody.data.userWatch.notificationEnabled).toBe(true)
+      expect(responseBody.data.userWatch.watchReleases).toBe(true)
+      expect(responseBody.data.userWatch.watchIssues).toBe(false)
+      expect(responseBody.data.userWatch.watchPullRequests).toBe(false)
+    })
+  })
+
+  describe("異常系", () => {
+    test("無効なリクエストボディの場合は400エラー", async () => {
+      const invalidRequestBody = {
+        repositoryUrl: "", // 空文字列は無効
+      }
+
+      const res = await app.request("/", {
+        method: "POST",
+        headers: {
+          ...AuthTestHelper.createAuthHeaders(testToken),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(invalidRequestBody),
+      })
+
+      expect(res.status).toBe(400)
+    })
+
+    test("認証情報がない場合は認証エラー", async () => {
+      const requestBody = {
+        repositoryUrl: "https://github.com/facebook/react",
+      }
+
+      const res = await app.request("/", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+      })
+
+      // 認証エラーまたは401ステータスが返される
+      expect(res.status).toBe(401)
+    })
+
+    test("重複エラーの場合は409エラー", async () => {
+      const requestBody = {
+        repositoryUrl: "https://github.com/facebook/react",
+      }
+
+      // GitHubスタブレスポンスを設定
+      const githubResponse: GitHubRepositoryResponse = {
+        id: 10270250,
+        full_name: "facebook/react",
+        name: "react",
+        description:
+          "A declarative, efficient, and flexible JavaScript library for building user interfaces.",
+        html_url: "https://github.com/facebook/react",
+        private: false,
+        language: "JavaScript",
+        stargazers_count: 230000,
+        forks_count: 47000,
+        open_issues_count: 1500,
+        fork: false,
+      }
+      githubStub.setStubResponse("facebook/react", githubResponse)
+
+      // 最初のリクエストで同じリポジトリを作成
+      await app.request("/", {
+        method: "POST",
+        headers: {
+          ...AuthTestHelper.createAuthHeaders(testToken),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+      })
+
+      // 2回目のリクエストで重複エラーが発生することを確認
+      const res = await app.request("/", {
+        method: "POST",
+        headers: {
+          ...AuthTestHelper.createAuthHeaders(testToken),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+      })
+
+      expect(res.status).toBe(409)
+
+      const responseBody = await res.json()
+      expect(responseBody.success).toBe(false)
+      expect(responseBody.error.code).toBe("DUPLICATE_REPOSITORY")
+    })
+
+    test("GitHub APIエラーの場合は適切なエラーレスポンス", async () => {
+      const requestBody = {
+        repositoryUrl: "https://github.com/nonexistent/repo",
+      }
+
+      // GitHubスタブでエラーシナリオを設定
+      githubStub.setErrorScenario("nonexistent/repo", {
+        status: 404,
+        message: "Repository nonexistent/repo not found or not accessible",
+      })
+
+      const res = await app.request("/", {
+        method: "POST",
+        headers: {
+          ...AuthTestHelper.createAuthHeaders(testToken),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+      })
+
+      expect(res.status).toBe(404)
+
+      const responseBody = await res.json()
+      expect(responseBody.success).toBe(false)
+      expect(responseBody.error.code).toBe("REPOSITORY_NOT_FOUND")
+    })
+  })
+})

--- a/packages/backend/src/features/data-sources/presentation/routes/data-sources/index.ts
+++ b/packages/backend/src/features/data-sources/presentation/routes/data-sources/index.ts
@@ -1,0 +1,126 @@
+import { OpenAPIHono, createRoute } from "@hono/zod-openapi"
+import { requireAuth } from "../../../../auth/middleware/jwt-auth.middleware"
+import type { DataSourceCreationService } from "../../../services"
+import {
+  createDataSourceRequestSchema,
+  createDataSourceResponseSchema,
+  dataSourceErrorResponseSchemaDefinition,
+} from "../../schemas"
+import { handleDataSourceError } from "../../shared/error-handling"
+
+/**
+ * POST /data-sources ルート定義
+ */
+const createDataSourceRoute = createRoute({
+  method: "post",
+  path: "/",
+  summary: "データソース登録",
+  description:
+    "GitHubリポジトリをデータソースとして登録し、ユーザーの監視対象に追加します",
+  tags: ["DataSources"],
+  security: [{ Bearer: [] }],
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: createDataSourceRequestSchema,
+        },
+      },
+      description: "データソース作成リクエスト",
+    },
+  },
+  responses: {
+    201: {
+      content: {
+        "application/json": {
+          schema: createDataSourceResponseSchema,
+        },
+      },
+      description: "データソースが正常に作成されました",
+    },
+    ...dataSourceErrorResponseSchemaDefinition,
+  },
+})
+
+/**
+ * データソースルートファクトリー
+ */
+export function createDataSourceRoutes(
+  dataSourceCreationService: DataSourceCreationService,
+) {
+  const app = new OpenAPIHono()
+
+  /**
+   * POST /data-sources - データソース作成エンドポイント
+   */
+  app.openapi(createDataSourceRoute, async (c) => {
+    try {
+      // 認証情報を取得
+      const authenticatedUser = requireAuth(c)
+      const auth0UserId = authenticatedUser.sub
+
+      // リクエストボディを取得
+      const body = c.req.valid("json")
+
+      // サービス層でデータソースを作成
+      const result = await dataSourceCreationService.execute({
+        repositoryUrl: body.repositoryUrl,
+        userId: auth0UserId,
+        name: body.name,
+        description: body.description,
+        notificationEnabled: body.notificationEnabled,
+        watchReleases: body.watchReleases,
+        watchIssues: body.watchIssues,
+        watchPullRequests: body.watchPullRequests,
+      })
+
+      // レスポンスを返す
+      return c.json(
+        {
+          success: true,
+          data: {
+            dataSource: {
+              id: result.dataSource.id,
+              sourceType: result.dataSource.sourceType,
+              sourceId: result.dataSource.sourceId,
+              name: result.dataSource.name,
+              description: result.dataSource.description,
+              url: result.dataSource.url,
+              isPrivate: result.dataSource.isPrivate,
+              createdAt: result.dataSource.createdAt.toISOString(),
+              updatedAt: result.dataSource.updatedAt.toISOString(),
+            },
+            repository: {
+              id: result.repository.id,
+              dataSourceId: result.repository.dataSourceId,
+              githubId: result.repository.githubId,
+              fullName: result.repository.fullName,
+              language: result.repository.language,
+              starsCount: result.repository.starsCount,
+              forksCount: result.repository.forksCount,
+              openIssuesCount: result.repository.openIssuesCount,
+              isFork: result.repository.isFork,
+              createdAt: result.repository.createdAt.toISOString(),
+              updatedAt: result.repository.updatedAt.toISOString(),
+            },
+            userWatch: {
+              id: result.userWatch.id,
+              userId: result.userWatch.userId,
+              dataSourceId: result.userWatch.dataSourceId,
+              notificationEnabled: result.userWatch.notificationEnabled,
+              watchReleases: result.userWatch.watchReleases,
+              watchIssues: result.userWatch.watchIssues,
+              watchPullRequests: result.userWatch.watchPullRequests,
+              addedAt: result.userWatch.addedAt.toISOString(),
+            },
+          },
+        },
+        201,
+      )
+    } catch (error) {
+      return handleDataSourceError(c, error, "creation")
+    }
+  })
+
+  return app
+}

--- a/packages/backend/src/features/data-sources/presentation/routes/e2e-control/index.ts
+++ b/packages/backend/src/features/data-sources/presentation/routes/e2e-control/index.ts
@@ -1,0 +1,248 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi"
+import type { GitHubApiServiceStub } from "../../../services/github-api-service.stub"
+import { createGitHubApiService } from "../../../services/github-api-service.factory"
+import type { GitHubRepositoryResponse } from "../../../services/interfaces/github-api-service.interface"
+
+/**
+ * E2Eテスト制御用APIルート
+ * スタブサービスの制御を行うエンドポイント
+ */
+
+// スタブレスポンス設定のスキーマ
+const StubResponseSchema = z.object({
+  key: z.string().describe("リポジトリキー (owner/repo)"),
+  response: z
+    .object({
+      id: z.number(),
+      full_name: z.string(),
+      name: z.string(),
+      description: z.string().nullable(),
+      html_url: z.string(),
+      private: z.boolean(),
+      language: z.string().nullable(),
+      stargazers_count: z.number(),
+      forks_count: z.number(),
+      open_issues_count: z.number(),
+      fork: z.boolean(),
+    })
+    .describe("GitHubレスポンス"),
+})
+
+// エラーシナリオ設定のスキーマ
+const ErrorScenarioSchema = z.object({
+  key: z.string().describe("リポジトリキー (owner/repo)"),
+  error: z
+    .object({
+      status: z.number().describe("HTTPステータスコード"),
+      message: z.string().describe("エラーメッセージ"),
+    })
+    .describe("エラー情報"),
+})
+
+// レスポンススキーマ
+const SuccessResponseSchema = z.object({
+  success: z.literal(true),
+  message: z.string(),
+})
+
+// スタブレスポンス設定ルート
+const setStubResponseRoute = createRoute({
+  method: "post",
+  path: "/e2e-control/github/stub-response",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: StubResponseSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: SuccessResponseSchema,
+        },
+      },
+      description: "スタブレスポンス設定成功",
+    },
+    400: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            success: z.literal(false),
+            error: z.string(),
+          }),
+        },
+      },
+      description: "不正なリクエスト",
+    },
+  },
+  tags: ["E2E Control"],
+  summary: "GitHubスタブレスポンス設定",
+  description: "特定のリポジトリに対するスタブレスポンスを設定",
+})
+
+// エラーシナリオ設定ルート
+const setErrorScenarioRoute = createRoute({
+  method: "post",
+  path: "/e2e-control/github/error-scenario",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: ErrorScenarioSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: SuccessResponseSchema,
+        },
+      },
+      description: "エラーシナリオ設定成功",
+    },
+    400: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            success: z.literal(false),
+            error: z.string(),
+          }),
+        },
+      },
+      description: "不正なリクエスト",
+    },
+  },
+  tags: ["E2E Control"],
+  summary: "GitHubエラーシナリオ設定",
+  description: "特定のリポジトリに対するエラーシナリオを設定",
+})
+
+// スタブリセットルート
+const resetStubsRoute = createRoute({
+  method: "post",
+  path: "/e2e-control/github/reset",
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: SuccessResponseSchema,
+        },
+      },
+      description: "スタブリセット成功",
+    },
+    400: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            success: z.literal(false),
+            error: z.string(),
+          }),
+        },
+      },
+      description: "リセット失敗",
+    },
+  },
+  tags: ["E2E Control"],
+  summary: "GitHubスタブリセット",
+  description: "すべてのスタブ設定をリセット",
+})
+
+/**
+ * E2Eテスト制御ルートを作成
+ */
+export function createE2EControlRoutes(): OpenAPIHono {
+  const app = new OpenAPIHono()
+
+  // スタブサービスのインスタンスを取得
+  const getStubService = (): GitHubApiServiceStub => {
+    const service = createGitHubApiService()
+    if (!("setStubResponse" in service)) {
+      throw new Error("E2E control is only available with stub service")
+    }
+    return service as GitHubApiServiceStub
+  }
+
+  // スタブレスポンス設定
+  app.openapi(setStubResponseRoute, async (c) => {
+    try {
+      const { key, response } = c.req.valid("json")
+      const stubService = getStubService()
+
+      stubService.setStubResponse(key, response as GitHubRepositoryResponse)
+
+      return c.json(
+        {
+          success: true as const,
+          message: `Stub response set for ${key}`,
+        },
+        200,
+      )
+    } catch (error) {
+      return c.json(
+        {
+          success: false as const,
+          error: error instanceof Error ? error.message : "Unknown error",
+        },
+        400,
+      )
+    }
+  })
+
+  // エラーシナリオ設定
+  app.openapi(setErrorScenarioRoute, async (c) => {
+    try {
+      const { key, error } = c.req.valid("json")
+      const stubService = getStubService()
+
+      stubService.setErrorScenario(key, error)
+
+      return c.json(
+        {
+          success: true as const,
+          message: `Error scenario set for ${key}`,
+        },
+        200,
+      )
+    } catch (error) {
+      return c.json(
+        {
+          success: false as const,
+          error: error instanceof Error ? error.message : "Unknown error",
+        },
+        400,
+      )
+    }
+  })
+
+  // スタブリセット
+  app.openapi(resetStubsRoute, async (c) => {
+    try {
+      const stubService = getStubService()
+      stubService.resetStubs()
+
+      return c.json(
+        {
+          success: true as const,
+          message: "All stubs reset successfully",
+        },
+        200,
+      )
+    } catch (error) {
+      return c.json(
+        {
+          success: false as const,
+          error: error instanceof Error ? error.message : "Unknown error",
+        },
+        400,
+      )
+    }
+  })
+
+  return app
+}

--- a/packages/backend/src/features/data-sources/presentation/schemas/data-source-error.schema.ts
+++ b/packages/backend/src/features/data-sources/presentation/schemas/data-source-error.schema.ts
@@ -1,0 +1,92 @@
+import { z } from "@hono/zod-openapi"
+
+/**
+ * エラーレスポンスの詳細情報スキーマ
+ */
+export const errorDetailsSchema = z
+  .object({
+    field: z.string().optional().openapi({
+      example: "repositoryUrl",
+      description: "エラーが発生したフィールド名",
+    }),
+    value: z.string().optional().openapi({
+      example: "invalid-url",
+      description: "エラーが発生した値",
+    }),
+  })
+  .openapi("ErrorDetails")
+
+/**
+ * エラーレスポンススキーマ
+ */
+export const dataSourceErrorSchema = z
+  .object({
+    success: z.boolean().openapi({
+      example: false,
+      description: "成功フラグ（常にfalse）",
+    }),
+    error: z
+      .object({
+        code: z.string().openapi({
+          example: "INVALID_REPOSITORY_URL",
+          description: "エラーコード",
+        }),
+        message: z.string().openapi({
+          example: "無効なGitHubリポジトリURLです",
+          description: "エラーメッセージ",
+        }),
+        details: errorDetailsSchema.optional().openapi({
+          description: "エラーの詳細情報",
+        }),
+      })
+      .openapi({
+        description: "エラー情報",
+      }),
+  })
+  .openapi("DataSourceError")
+
+/**
+ * データソース関連のエラーレスポンス定義
+ */
+export const dataSourceErrorResponseSchemaDefinition = {
+  400: {
+    content: {
+      "application/json": {
+        schema: dataSourceErrorSchema,
+      },
+    },
+    description: "バリデーションエラー、無効なリクエスト",
+  },
+  401: {
+    content: {
+      "application/json": {
+        schema: dataSourceErrorSchema,
+      },
+    },
+    description: "認証エラー",
+  },
+  404: {
+    content: {
+      "application/json": {
+        schema: dataSourceErrorSchema,
+      },
+    },
+    description: "リポジトリが見つからない",
+  },
+  409: {
+    content: {
+      "application/json": {
+        schema: dataSourceErrorSchema,
+      },
+    },
+    description: "重複エラー（リポジトリが既に登録済み）",
+  },
+  500: {
+    content: {
+      "application/json": {
+        schema: dataSourceErrorSchema,
+      },
+    },
+    description: "サーバーエラー",
+  },
+}

--- a/packages/backend/src/features/data-sources/presentation/schemas/data-source-request.schema.ts
+++ b/packages/backend/src/features/data-sources/presentation/schemas/data-source-request.schema.ts
@@ -1,0 +1,42 @@
+import { z } from "@hono/zod-openapi"
+
+/**
+ * データソース作成リクエストスキーマ
+ */
+export const createDataSourceRequestSchema = z
+  .object({
+    repositoryUrl: z.string().min(1, "リポジトリURLは必須です").openapi({
+      example: "https://github.com/facebook/react",
+      description: "GitHubリポジトリのURL",
+    }),
+    name: z.string().optional().openapi({
+      example: "React",
+      description: "カスタム表示名（省略時はリポジトリ名を使用）",
+    }),
+    description: z.string().optional().openapi({
+      example:
+        "A declarative, efficient, and flexible JavaScript library for building user interfaces.",
+      description: "カスタム説明（省略時はリポジトリの説明を使用）",
+    }),
+    notificationEnabled: z.boolean().optional().default(true).openapi({
+      example: true,
+      description: "通知を有効にするか（デフォルト: true）",
+    }),
+    watchReleases: z.boolean().optional().default(true).openapi({
+      example: true,
+      description: "リリースを監視するか（デフォルト: true）",
+    }),
+    watchIssues: z.boolean().optional().default(false).openapi({
+      example: false,
+      description: "イシューを監視するか（デフォルト: false）",
+    }),
+    watchPullRequests: z.boolean().optional().default(false).openapi({
+      example: false,
+      description: "プルリクエストを監視するか（デフォルト: false）",
+    }),
+  })
+  .openapi("CreateDataSourceRequest")
+
+export type CreateDataSourceRequest = z.infer<
+  typeof createDataSourceRequestSchema
+>

--- a/packages/backend/src/features/data-sources/presentation/schemas/data-source-response.schema.ts
+++ b/packages/backend/src/features/data-sources/presentation/schemas/data-source-response.schema.ts
@@ -1,0 +1,163 @@
+import { z } from "@hono/zod-openapi"
+
+/**
+ * データソースレスポンススキーマ
+ */
+export const dataSourceSchema = z
+  .object({
+    id: z.string().openapi({
+      example: "01234567-89ab-cdef-0123-456789abcdef",
+      description: "データソースID",
+    }),
+    sourceType: z.string().openapi({
+      example: "github",
+      description: "データソースタイプ",
+    }),
+    sourceId: z.string().openapi({
+      example: "123456789",
+      description: "外部サービスでのID",
+    }),
+    name: z.string().openapi({
+      example: "React",
+      description: "データソース名",
+    }),
+    description: z.string().openapi({
+      example:
+        "A declarative, efficient, and flexible JavaScript library for building user interfaces.",
+      description: "データソースの説明",
+    }),
+    url: z.string().openapi({
+      example: "https://github.com/facebook/react",
+      description: "データソースのURL",
+    }),
+    isPrivate: z.boolean().openapi({
+      example: false,
+      description: "プライベートリポジトリかどうか",
+    }),
+    createdAt: z.string().openapi({
+      example: "2024-07-08T10:00:00.000Z",
+      description: "作成日時",
+    }),
+    updatedAt: z.string().openapi({
+      example: "2024-07-08T10:00:00.000Z",
+      description: "更新日時",
+    }),
+  })
+  .openapi("DataSource")
+
+/**
+ * リポジトリレスポンススキーマ
+ */
+export const repositorySchema = z
+  .object({
+    id: z.string().openapi({
+      example: "01234567-89ab-cdef-0123-456789abcdef",
+      description: "リポジトリID",
+    }),
+    dataSourceId: z.string().openapi({
+      example: "01234567-89ab-cdef-0123-456789abcdef",
+      description: "データソースID",
+    }),
+    githubId: z.number().openapi({
+      example: 10270250,
+      description: "GitHub リポジトリID",
+    }),
+    fullName: z.string().openapi({
+      example: "facebook/react",
+      description: "リポジトリのフルネーム",
+    }),
+    language: z.string().nullable().openapi({
+      example: "JavaScript",
+      description: "主要プログラミング言語",
+    }),
+    starsCount: z.number().openapi({
+      example: 230000,
+      description: "スター数",
+    }),
+    forksCount: z.number().openapi({
+      example: 47000,
+      description: "フォーク数",
+    }),
+    openIssuesCount: z.number().openapi({
+      example: 1500,
+      description: "未解決イシュー数",
+    }),
+    isFork: z.boolean().openapi({
+      example: false,
+      description: "フォークリポジトリかどうか",
+    }),
+    createdAt: z.string().openapi({
+      example: "2024-07-08T10:00:00.000Z",
+      description: "作成日時",
+    }),
+    updatedAt: z.string().openapi({
+      example: "2024-07-08T10:00:00.000Z",
+      description: "更新日時",
+    }),
+  })
+  .openapi("Repository")
+
+/**
+ * ユーザーウォッチレスポンススキーマ
+ */
+export const userWatchSchema = z
+  .object({
+    id: z.string().openapi({
+      example: "01234567-89ab-cdef-0123-456789abcdef",
+      description: "ユーザーウォッチID",
+    }),
+    userId: z.string().openapi({
+      example: "01234567-89ab-cdef-0123-456789abcdef",
+      description: "ユーザーID",
+    }),
+    dataSourceId: z.string().openapi({
+      example: "01234567-89ab-cdef-0123-456789abcdef",
+      description: "データソースID",
+    }),
+    notificationEnabled: z.boolean().openapi({
+      example: true,
+      description: "通知が有効かどうか",
+    }),
+    watchReleases: z.boolean().openapi({
+      example: true,
+      description: "リリースを監視するか",
+    }),
+    watchIssues: z.boolean().openapi({
+      example: false,
+      description: "イシューを監視するか",
+    }),
+    watchPullRequests: z.boolean().openapi({
+      example: false,
+      description: "プルリクエストを監視するか",
+    }),
+    addedAt: z.string().openapi({
+      example: "2024-07-08T10:00:00.000Z",
+      description: "追加日時",
+    }),
+  })
+  .openapi("UserWatch")
+
+/**
+ * データソース作成レスポンススキーマ
+ */
+export const createDataSourceResponseSchema = z
+  .object({
+    success: z.boolean().openapi({
+      example: true,
+      description: "成功フラグ",
+    }),
+    data: z
+      .object({
+        dataSource: dataSourceSchema,
+        repository: repositorySchema,
+        userWatch: userWatchSchema,
+      })
+      .openapi({
+        description: "作成されたデータ",
+      }),
+  })
+  .openapi("CreateDataSourceResponse")
+
+export type CreateDataSourceResponse = z.infer<
+  typeof createDataSourceResponseSchema
+>

--- a/packages/backend/src/features/data-sources/presentation/schemas/index.ts
+++ b/packages/backend/src/features/data-sources/presentation/schemas/index.ts
@@ -1,0 +1,4 @@
+// データソーススキーマのエクスポート
+export * from "./data-source-request.schema"
+export * from "./data-source-response.schema"
+export * from "./data-source-error.schema"

--- a/packages/backend/src/features/data-sources/presentation/shared/error-handling.ts
+++ b/packages/backend/src/features/data-sources/presentation/shared/error-handling.ts
@@ -1,0 +1,193 @@
+import type { Context } from "hono"
+import { DuplicateDataSourceError, GitHubApiError } from "../../errors"
+
+/**
+ * データソースエラーコード定義
+ */
+export const DATA_SOURCE_ERROR_CODES = {
+  INVALID_REPOSITORY_URL: "INVALID_REPOSITORY_URL",
+  REPOSITORY_NOT_FOUND: "REPOSITORY_NOT_FOUND",
+  REPOSITORY_ACCESS_DENIED: "REPOSITORY_ACCESS_DENIED",
+  DUPLICATE_REPOSITORY: "DUPLICATE_REPOSITORY",
+  GITHUB_API_ERROR: "GITHUB_API_ERROR",
+  INTERNAL_ERROR: "INTERNAL_ERROR",
+} as const
+
+export type DataSourceErrorCode =
+  (typeof DATA_SOURCE_ERROR_CODES)[keyof typeof DATA_SOURCE_ERROR_CODES]
+
+/**
+ * エラー詳細情報の型定義
+ */
+export type ErrorDetails = {
+  field?: string
+  value?: string
+}
+
+/**
+ * データソースカスタムエラークラス
+ */
+export class DataSourceError extends Error {
+  public readonly code: DataSourceErrorCode
+  public readonly httpStatus: number
+  public readonly details?: ErrorDetails
+
+  constructor(params: {
+    code: DataSourceErrorCode
+    message: string
+    httpStatus: number
+    details?: ErrorDetails
+  }) {
+    super(params.message)
+    this.name = "DataSourceError"
+    this.code = params.code
+    this.httpStatus = params.httpStatus
+    this.details = params.details
+  }
+
+  static invalidRepositoryUrl(url?: string): DataSourceError {
+    return new DataSourceError({
+      code: DATA_SOURCE_ERROR_CODES.INVALID_REPOSITORY_URL,
+      message: "無効なGitHubリポジトリURLです",
+      httpStatus: 400,
+      details: { field: "repositoryUrl", value: url },
+    })
+  }
+
+  static repositoryNotFound(repositoryName?: string): DataSourceError {
+    return new DataSourceError({
+      code: DATA_SOURCE_ERROR_CODES.REPOSITORY_NOT_FOUND,
+      message: "指定されたリポジトリが見つからないか、アクセスできません",
+      httpStatus: 404,
+      details: { field: "repositoryUrl", value: repositoryName },
+    })
+  }
+
+  static duplicateRepository(repositoryName?: string): DataSourceError {
+    return new DataSourceError({
+      code: DATA_SOURCE_ERROR_CODES.DUPLICATE_REPOSITORY,
+      message: "このリポジトリは既に登録されています",
+      httpStatus: 409,
+      details: { field: "repositoryUrl", value: repositoryName },
+    })
+  }
+
+  static githubApiError(message: string): DataSourceError {
+    return new DataSourceError({
+      code: DATA_SOURCE_ERROR_CODES.GITHUB_API_ERROR,
+      message: `GitHub APIエラー: ${message}`,
+      httpStatus: 500,
+    })
+  }
+
+  static internalError(message?: string): DataSourceError {
+    return new DataSourceError({
+      code: DATA_SOURCE_ERROR_CODES.INTERNAL_ERROR,
+      message: message || "内部サーバーエラーが発生しました",
+      httpStatus: 500,
+    })
+  }
+}
+
+/**
+ * データソース操作のエラーハンドリング
+ */
+export function handleDataSourceError(
+  c: Context,
+  error: unknown,
+  operation: string,
+) {
+  console.error(`Data source ${operation} error:`, error)
+
+  // 既知のカスタムエラー
+  if (error instanceof DataSourceError) {
+    return c.json(
+      {
+        success: false,
+        error: {
+          code: error.code,
+          message: error.message,
+          details: error.details,
+        },
+      },
+      error.httpStatus as 400 | 401 | 404 | 409 | 500,
+    )
+  }
+
+  // サービス層のエラー
+  if (error instanceof DuplicateDataSourceError) {
+    const dataSourceError = DataSourceError.duplicateRepository()
+    return c.json(
+      {
+        success: false,
+        error: {
+          code: dataSourceError.code,
+          message: dataSourceError.message,
+          details: dataSourceError.details,
+        },
+      },
+      dataSourceError.httpStatus as 409,
+    )
+  }
+
+  if (error instanceof GitHubApiError) {
+    if (error.status === 404) {
+      const dataSourceError = DataSourceError.repositoryNotFound()
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: dataSourceError.code,
+            message: dataSourceError.message,
+            details: dataSourceError.details,
+          },
+        },
+        dataSourceError.httpStatus as 404,
+      )
+    }
+
+    const dataSourceError = DataSourceError.githubApiError(error.message)
+    return c.json(
+      {
+        success: false,
+        error: {
+          code: dataSourceError.code,
+          message: dataSourceError.message,
+        },
+      },
+      dataSourceError.httpStatus as 500,
+    )
+  }
+
+  // 不明なエラー
+  if (
+    error instanceof Error &&
+    error.message.includes("Invalid GitHub repository URL")
+  ) {
+    const dataSourceError = DataSourceError.invalidRepositoryUrl()
+    return c.json(
+      {
+        success: false,
+        error: {
+          code: dataSourceError.code,
+          message: dataSourceError.message,
+          details: dataSourceError.details,
+        },
+      },
+      dataSourceError.httpStatus as 400,
+    )
+  }
+
+  // その他のエラー
+  const dataSourceError = DataSourceError.internalError()
+  return c.json(
+    {
+      success: false,
+      error: {
+        code: dataSourceError.code,
+        message: dataSourceError.message,
+      },
+    },
+    dataSourceError.httpStatus as 500,
+  )
+}

--- a/packages/backend/src/features/data-sources/repositories/__tests__/data-source.repository.test.ts
+++ b/packages/backend/src/features/data-sources/repositories/__tests__/data-source.repository.test.ts
@@ -1,0 +1,203 @@
+import { describe, test, expect, beforeEach } from "vitest"
+import { DataSourceRepository } from "../data-source.repository"
+import type { DataSourceCreationInput } from "../../domain"
+import { TestDataFactory, setupComponentTest } from "../../../../test"
+import { uuidv7 } from "uuidv7"
+
+// Repository Unit Test: 実DBを使用してデータアクセス層をテスト
+
+describe("DataSourceRepository - Unit Test", () => {
+  setupComponentTest()
+
+  let dataSourceRepository: DataSourceRepository
+
+  beforeEach(() => {
+    dataSourceRepository = new DataSourceRepository()
+  })
+
+  describe("save()", () => {
+    test("新規データソースのINSERTが正常に動作する", async () => {
+      const newDataSourceInput: DataSourceCreationInput = {
+        sourceType: "github",
+        sourceId: "987654321",
+        name: "新規リポジトリ",
+        description: "テスト用の新規リポジトリです",
+        url: "https://github.com/test/newrepo",
+        isPrivate: false,
+      }
+
+      // INSERT実行
+      const savedDataSource =
+        await dataSourceRepository.save(newDataSourceInput)
+
+      // データが正しく保存されているか確認
+      expect(savedDataSource.id).toBeDefined()
+      expect(savedDataSource.sourceType).toBe("github")
+      expect(savedDataSource.sourceId).toBe("987654321")
+      expect(savedDataSource.name).toBe("新規リポジトリ")
+      expect(savedDataSource.description).toBe("テスト用の新規リポジトリです")
+      expect(savedDataSource.url).toBe("https://github.com/test/newrepo")
+      expect(savedDataSource.isPrivate).toBe(false)
+      expect(savedDataSource.createdAt).toBeInstanceOf(Date)
+      expect(savedDataSource.updatedAt).toBeInstanceOf(Date)
+
+      // DBから取得して確認
+      const foundDataSource = await dataSourceRepository.findById(
+        savedDataSource.id,
+      )
+      expect(foundDataSource).not.toBeNull()
+      expect(foundDataSource?.name).toBe("新規リポジトリ")
+    })
+
+    test("既存データソースのUPDATEが正常に動作する（重複キーの場合）", async () => {
+      // 既存データソースを作成
+      const existingDataSource = await TestDataFactory.createTestDataSource({
+        sourceType: "github",
+        sourceId: "duplicate_test",
+        name: "元の名前",
+      })
+
+      const originalUpdatedAt = existingDataSource.updatedAt
+
+      // 少し待って時刻を変える
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 10))
+
+      // 同じsourceType + sourceIdで更新実行
+      const updateInput: DataSourceCreationInput = {
+        sourceType: "github",
+        sourceId: "duplicate_test",
+        name: "更新された名前",
+        description: "更新された説明",
+        url: "https://github.com/test/updated",
+        isPrivate: true,
+      }
+
+      const updatedDataSource = await dataSourceRepository.save(updateInput)
+
+      // データが正しく更新されているか確認
+      expect(updatedDataSource.name).toBe("更新された名前")
+      expect(updatedDataSource.description).toBe("更新された説明")
+      expect(updatedDataSource.isPrivate).toBe(true)
+      expect(updatedDataSource.updatedAt.getTime()).toBeGreaterThan(
+        originalUpdatedAt.getTime(),
+      )
+    })
+  })
+
+  describe("findById()", () => {
+    test("存在するデータソースIDで正常に取得できる", async () => {
+      const testDataSource = await TestDataFactory.createTestDataSource({
+        name: "findByIdテスト",
+        sourceId: "findbyid_test",
+      })
+
+      const foundDataSource = await dataSourceRepository.findById(
+        testDataSource.id,
+      )
+
+      expect(foundDataSource).not.toBeNull()
+      expect(foundDataSource?.id).toBe(testDataSource.id)
+      expect(foundDataSource?.name).toBe("findByIdテスト")
+      expect(foundDataSource?.sourceId).toBe("findbyid_test")
+    })
+
+    test("存在しないデータソースIDの場合はnullを返す", async () => {
+      const nonExistentId = uuidv7()
+
+      const foundDataSource = await dataSourceRepository.findById(nonExistentId)
+
+      expect(foundDataSource).toBeNull()
+    })
+  })
+
+  describe("findBySourceTypeAndId()", () => {
+    test("存在するsourceTypeとsourceIdで正常に取得できる", async () => {
+      await TestDataFactory.createTestDataSource({
+        sourceType: "github",
+        sourceId: "findbytype_test",
+        name: "findBySourceTypeAndIdテスト",
+      })
+
+      const foundDataSource = await dataSourceRepository.findBySourceTypeAndId(
+        "github",
+        "findbytype_test",
+      )
+
+      expect(foundDataSource).not.toBeNull()
+      expect(foundDataSource?.sourceType).toBe("github")
+      expect(foundDataSource?.sourceId).toBe("findbytype_test")
+      expect(foundDataSource?.name).toBe("findBySourceTypeAndIdテスト")
+    })
+
+    test("存在しないsourceTypeとsourceIdの場合はnullを返す", async () => {
+      const foundDataSource = await dataSourceRepository.findBySourceTypeAndId(
+        "github",
+        "nonexistent",
+      )
+
+      expect(foundDataSource).toBeNull()
+    })
+  })
+
+  describe("findMany()", () => {
+    test("フィルタなしで全データソースを取得できる", async () => {
+      // テストデータソースを複数作成
+      await TestDataFactory.createTestDataSource({ name: "テスト1" })
+      await TestDataFactory.createTestDataSource({ name: "テスト2" })
+      await TestDataFactory.createTestDataSource({ name: "テスト3" })
+
+      const dataSources = await dataSourceRepository.findMany()
+
+      expect(dataSources.length).toBeGreaterThanOrEqual(3)
+      expect(Array.isArray(dataSources)).toBe(true)
+    })
+
+    test("sourceTypeフィルタが正常に動作する", async () => {
+      await TestDataFactory.createTestDataSource({
+        sourceType: "github",
+        sourceId: "github_test",
+        name: "GitHubテスト",
+      })
+      await TestDataFactory.createTestDataSource({
+        sourceType: "npm",
+        sourceId: "npm_test",
+        name: "NPMテスト",
+      })
+
+      const githubDataSources = await dataSourceRepository.findMany({
+        sourceType: "github",
+      })
+
+      expect(githubDataSources.length).toBeGreaterThanOrEqual(1)
+      expect(githubDataSources.every((ds) => ds.sourceType === "github")).toBe(
+        true,
+      )
+    })
+  })
+
+  describe("delete()", () => {
+    test("存在するデータソースの削除が正常に動作する", async () => {
+      const testDataSource = await TestDataFactory.createTestDataSource({
+        name: "削除テスト",
+      })
+
+      const result = await dataSourceRepository.delete(testDataSource.id)
+
+      expect(result).toBe(true)
+
+      // 削除されたことを確認
+      const deletedDataSource = await dataSourceRepository.findById(
+        testDataSource.id,
+      )
+      expect(deletedDataSource).toBeNull()
+    })
+
+    test("存在しないデータソースの削除はfalseを返す", async () => {
+      const nonExistentId = uuidv7()
+
+      const result = await dataSourceRepository.delete(nonExistentId)
+
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/packages/backend/src/features/data-sources/repositories/data-source.repository.ts
+++ b/packages/backend/src/features/data-sources/repositories/data-source.repository.ts
@@ -1,0 +1,118 @@
+import { eq, and } from "drizzle-orm"
+import { randomUUID } from "crypto"
+import { db } from "../../../db/connection"
+import { dataSources } from "../../../db/schema"
+import type { DataSource, DataSourceCreationInput } from "../domain"
+
+/**
+ * データソースのリポジトリクラス
+ * 既存のUserRepositoryパターンに従った実装
+ */
+export class DataSourceRepository {
+  /**
+   * データソースを保存（作成・更新）
+   */
+  async save(data: DataSourceCreationInput): Promise<DataSource> {
+    const now = new Date()
+    const id = randomUUID()
+
+    const [result] = await db
+      .insert(dataSources)
+      .values({
+        id,
+        sourceType: data.sourceType,
+        sourceId: data.sourceId,
+        name: data.name,
+        description: data.description,
+        url: data.url,
+        isPrivate: data.isPrivate,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [dataSources.sourceType, dataSources.sourceId],
+        set: {
+          name: data.name,
+          description: data.description,
+          url: data.url,
+          isPrivate: data.isPrivate,
+          updatedAt: now,
+        },
+      })
+      .returning()
+
+    return this.mapToDomain(result)
+  }
+
+  /**
+   * IDでデータソースを検索
+   */
+  async findById(id: string): Promise<DataSource | null> {
+    const result = await db
+      .select()
+      .from(dataSources)
+      .where(eq(dataSources.id, id))
+
+    return result.length > 0 ? this.mapToDomain(result[0]) : null
+  }
+
+  /**
+   * ソースタイプとソースIDでデータソースを検索
+   */
+  async findBySourceTypeAndId(
+    sourceType: string,
+    sourceId: string,
+  ): Promise<DataSource | null> {
+    const result = await db
+      .select()
+      .from(dataSources)
+      .where(
+        and(
+          eq(dataSources.sourceType, sourceType),
+          eq(dataSources.sourceId, sourceId),
+        ),
+      )
+
+    return result.length > 0 ? this.mapToDomain(result[0]) : null
+  }
+
+  /**
+   * 複数のデータソースを検索
+   */
+  async findMany(filters?: { sourceType?: string }): Promise<DataSource[]> {
+    let query = db.select().from(dataSources).$dynamic()
+
+    if (filters?.sourceType) {
+      query = query.where(eq(dataSources.sourceType, filters.sourceType))
+    }
+
+    const results = await query
+    return results.map(this.mapToDomain)
+  }
+
+  /**
+   * データソースを削除
+   */
+  async delete(id: string): Promise<boolean> {
+    const result = await db.delete(dataSources).where(eq(dataSources.id, id))
+
+    return (result.rowCount ?? 0) > 0
+  }
+
+  /**
+   * データベース結果をドメイン型に変換
+   */
+  private mapToDomain(row: typeof dataSources.$inferSelect): DataSource {
+    return {
+      id: row.id,
+      sourceType: row.sourceType,
+      sourceId: row.sourceId,
+      name: row.name,
+      description: row.description,
+      url: row.url,
+      isPrivate: row.isPrivate,
+      createdAt: row.createdAt!,
+      updatedAt: row.updatedAt!,
+    }
+  }
+}

--- a/packages/backend/src/features/data-sources/repositories/index.ts
+++ b/packages/backend/src/features/data-sources/repositories/index.ts
@@ -1,0 +1,4 @@
+// データソースリポジトリのエクスポート
+export * from "./data-source.repository"
+export * from "./repository.repository"
+export * from "./user-watch.repository"

--- a/packages/backend/src/features/data-sources/repositories/repository.repository.ts
+++ b/packages/backend/src/features/data-sources/repositories/repository.repository.ts
@@ -1,0 +1,115 @@
+import { eq } from "drizzle-orm"
+import { randomUUID } from "crypto"
+import { db } from "../../../db/connection"
+import { repositories } from "../../../db/schema"
+import type { Repository, RepositoryCreationInput } from "../domain"
+
+/**
+ * GitHubリポジトリのリポジトリクラス
+ * 既存のUserRepositoryパターンに従った実装
+ */
+export class RepositoryRepository {
+  /**
+   * リポジトリを保存（作成・更新）
+   */
+  async save(data: RepositoryCreationInput): Promise<Repository> {
+    const now = new Date()
+    const id = randomUUID()
+
+    const [result] = await db
+      .insert(repositories)
+      .values({
+        id,
+        dataSourceId: data.dataSourceId,
+        githubId: data.githubId,
+        fullName: data.fullName,
+        language: data.language,
+        starsCount: data.starsCount,
+        forksCount: data.forksCount,
+        openIssuesCount: data.openIssuesCount,
+        isFork: data.isFork,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [repositories.githubId],
+        set: {
+          dataSourceId: data.dataSourceId,
+          fullName: data.fullName,
+          language: data.language,
+          starsCount: data.starsCount,
+          forksCount: data.forksCount,
+          openIssuesCount: data.openIssuesCount,
+          isFork: data.isFork,
+          updatedAt: now,
+        },
+      })
+      .returning()
+
+    return this.mapToDomain(result)
+  }
+
+  /**
+   * IDでリポジトリを検索
+   */
+  async findById(id: string): Promise<Repository | null> {
+    const result = await db
+      .select()
+      .from(repositories)
+      .where(eq(repositories.id, id))
+
+    return result.length > 0 ? this.mapToDomain(result[0]) : null
+  }
+
+  /**
+   * データソースIDでリポジトリを検索
+   */
+  async findByDataSourceId(dataSourceId: string): Promise<Repository | null> {
+    const result = await db
+      .select()
+      .from(repositories)
+      .where(eq(repositories.dataSourceId, dataSourceId))
+
+    return result.length > 0 ? this.mapToDomain(result[0]) : null
+  }
+
+  /**
+   * GitHub IDでリポジトリを検索
+   */
+  async findByGithubId(githubId: number): Promise<Repository | null> {
+    const result = await db
+      .select()
+      .from(repositories)
+      .where(eq(repositories.githubId, githubId))
+
+    return result.length > 0 ? this.mapToDomain(result[0]) : null
+  }
+
+  /**
+   * リポジトリを削除
+   */
+  async delete(id: string): Promise<boolean> {
+    const result = await db.delete(repositories).where(eq(repositories.id, id))
+
+    return (result.rowCount ?? 0) > 0
+  }
+
+  /**
+   * データベース結果をドメイン型に変換
+   */
+  private mapToDomain(row: typeof repositories.$inferSelect): Repository {
+    return {
+      id: row.id,
+      dataSourceId: row.dataSourceId,
+      githubId: row.githubId,
+      fullName: row.fullName,
+      language: row.language,
+      starsCount: row.starsCount,
+      forksCount: row.forksCount,
+      openIssuesCount: row.openIssuesCount,
+      isFork: row.isFork,
+      createdAt: row.createdAt!,
+      updatedAt: row.updatedAt!,
+    }
+  }
+}

--- a/packages/backend/src/features/data-sources/repositories/user-watch.repository.ts
+++ b/packages/backend/src/features/data-sources/repositories/user-watch.repository.ts
@@ -1,0 +1,132 @@
+import { eq, and } from "drizzle-orm"
+import { randomUUID } from "crypto"
+import { db } from "../../../db/connection"
+import { userWatches } from "../../../db/schema"
+import type { UserWatch, UserWatchCreationInput } from "../domain"
+
+/**
+ * ユーザーウォッチのリポジトリクラス
+ * 既存のUserRepositoryパターンに従った実装
+ */
+export class UserWatchRepository {
+  /**
+   * ユーザーウォッチを保存（作成・更新）
+   */
+  async save(data: UserWatchCreationInput): Promise<UserWatch> {
+    const now = new Date()
+    const id = randomUUID()
+
+    const [result] = await db
+      .insert(userWatches)
+      .values({
+        id,
+        userId: data.userId,
+        dataSourceId: data.dataSourceId,
+        notificationEnabled: data.notificationEnabled,
+        watchReleases: data.watchReleases,
+        watchIssues: data.watchIssues,
+        watchPullRequests: data.watchPullRequests,
+        addedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [userWatches.userId, userWatches.dataSourceId],
+        set: {
+          notificationEnabled: data.notificationEnabled,
+          watchReleases: data.watchReleases,
+          watchIssues: data.watchIssues,
+          watchPullRequests: data.watchPullRequests,
+        },
+      })
+      .returning()
+
+    return this.mapToDomain(result)
+  }
+
+  /**
+   * IDでユーザーウォッチを検索
+   */
+  async findById(id: string): Promise<UserWatch | null> {
+    const result = await db
+      .select()
+      .from(userWatches)
+      .where(eq(userWatches.id, id))
+
+    return result.length > 0 ? this.mapToDomain(result[0]) : null
+  }
+
+  /**
+   * ユーザーIDとデータソースIDでユーザーウォッチを検索
+   */
+  async findByUserAndDataSource(
+    userId: string,
+    dataSourceId: string,
+  ): Promise<UserWatch | null> {
+    const result = await db
+      .select()
+      .from(userWatches)
+      .where(
+        and(
+          eq(userWatches.userId, userId),
+          eq(userWatches.dataSourceId, dataSourceId),
+        ),
+      )
+
+    return result.length > 0 ? this.mapToDomain(result[0]) : null
+  }
+
+  /**
+   * ユーザーIDで複数のユーザーウォッチを検索
+   */
+  async findByUserId(userId: string): Promise<UserWatch[]> {
+    const results = await db
+      .select()
+      .from(userWatches)
+      .where(eq(userWatches.userId, userId))
+
+    return results.map(this.mapToDomain)
+  }
+
+  /**
+   * ユーザーウォッチを削除
+   */
+  async delete(id: string): Promise<boolean> {
+    const result = await db.delete(userWatches).where(eq(userWatches.id, id))
+
+    return (result.rowCount ?? 0) > 0
+  }
+
+  /**
+   * ユーザーIDとデータソースIDで削除
+   */
+  async deleteByUserAndDataSource(
+    userId: string,
+    dataSourceId: string,
+  ): Promise<boolean> {
+    const result = await db
+      .delete(userWatches)
+      .where(
+        and(
+          eq(userWatches.userId, userId),
+          eq(userWatches.dataSourceId, dataSourceId),
+        ),
+      )
+
+    return (result.rowCount ?? 0) > 0
+  }
+
+  /**
+   * データベース結果をドメイン型に変換
+   */
+  private mapToDomain(row: typeof userWatches.$inferSelect): UserWatch {
+    return {
+      id: row.id,
+      userId: row.userId,
+      dataSourceId: row.dataSourceId,
+      notificationEnabled: row.notificationEnabled,
+      watchReleases: row.watchReleases,
+      watchIssues: row.watchIssues,
+      watchPullRequests: row.watchPullRequests,
+      addedAt: row.addedAt!,
+    }
+  }
+}

--- a/packages/backend/src/features/data-sources/services/data-source-creation.service.ts
+++ b/packages/backend/src/features/data-sources/services/data-source-creation.service.ts
@@ -1,0 +1,140 @@
+import type { DataSource, Repository, UserWatch } from "../domain"
+import { DATA_SOURCE_TYPES } from "../domain"
+import type {
+  DataSourceRepository,
+  RepositoryRepository,
+  UserWatchRepository,
+} from "../repositories"
+import type { UserRepository } from "../../user/repositories/user.repository"
+import { DuplicateDataSourceError } from "../errors"
+import type { GitHubApiServiceInterface } from "./interfaces/github-api-service.interface"
+import { createGitHubApiService } from "./github-api-service.factory"
+
+/**
+ * データソース作成サービスの入力DTO
+ */
+export type CreateDataSourceInputDto = {
+  repositoryUrl: string
+  userId: string
+  name?: string
+  description?: string
+  notificationEnabled?: boolean
+  watchReleases?: boolean
+  watchIssues?: boolean
+  watchPullRequests?: boolean
+}
+
+/**
+ * データソース作成サービスの出力DTO
+ */
+export type CreateDataSourceOutputDto = {
+  dataSource: DataSource
+  repository: Repository
+  userWatch: UserWatch
+}
+
+/**
+ * データソース作成サービス
+ * GitHub リポジトリ URL からデータソース、リポジトリ、ユーザーウォッチを作成
+ */
+export class DataSourceCreationService {
+  constructor(
+    private dataSourceRepository: DataSourceRepository,
+    private repositoryRepository: RepositoryRepository,
+    private userWatchRepository: UserWatchRepository,
+    private userRepository: UserRepository,
+    private githubApiService?: GitHubApiServiceInterface,
+  ) {
+    // githubApiServiceが指定されていない場合はファクトリ関数を使用
+    if (!this.githubApiService) {
+      this.githubApiService = createGitHubApiService()
+    }
+  }
+
+  /**
+   * GitHub リポジトリ URL からデータソースを作成
+   */
+  async execute(
+    input: CreateDataSourceInputDto,
+  ): Promise<CreateDataSourceOutputDto> {
+    // GitHub URL から owner/repo を抽出
+    const { owner, repo } = this.parseGitHubUrl(input.repositoryUrl)
+
+    // GitHub API でリポジトリ情報を取得
+    const githubRepo = await this.githubApiService!.getRepository(owner, repo)
+
+    // 重複チェック
+    const existingDataSource =
+      await this.dataSourceRepository.findBySourceTypeAndId(
+        DATA_SOURCE_TYPES.GITHUB,
+        githubRepo.id.toString(),
+      )
+
+    if (existingDataSource) {
+      throw new DuplicateDataSourceError(
+        `Repository ${githubRepo.full_name} is already registered`,
+      )
+    }
+
+    // データソース作成
+    const dataSource = await this.dataSourceRepository.save({
+      sourceType: DATA_SOURCE_TYPES.GITHUB,
+      sourceId: githubRepo.id.toString(),
+      name: input.name || githubRepo.name,
+      description: input.description || githubRepo.description || "",
+      url: githubRepo.html_url,
+      isPrivate: githubRepo.private,
+    })
+
+    // リポジトリ情報作成
+    const repository = await this.repositoryRepository.save({
+      dataSourceId: dataSource.id,
+      githubId: githubRepo.id,
+      fullName: githubRepo.full_name,
+      language: githubRepo.language,
+      starsCount: githubRepo.stargazers_count,
+      forksCount: githubRepo.forks_count,
+      openIssuesCount: githubRepo.open_issues_count,
+      isFork: githubRepo.fork,
+    })
+
+    // Auth0 UserIDからユーザーのDBレコードを取得
+    const user = await this.userRepository.findByAuth0Id(input.userId)
+    if (!user) {
+      throw new Error(`User not found for auth0UserId: ${input.userId}`)
+    }
+
+    // ユーザーウォッチ作成
+    const userWatch = await this.userWatchRepository.save({
+      userId: user.id,
+      dataSourceId: dataSource.id,
+      notificationEnabled: input.notificationEnabled ?? true,
+      watchReleases: input.watchReleases ?? true,
+      watchIssues: input.watchIssues ?? false,
+      watchPullRequests: input.watchPullRequests ?? false,
+    })
+
+    return {
+      dataSource,
+      repository,
+      userWatch,
+    }
+  }
+
+  /**
+   * GitHub URL から owner/repo を抽出
+   */
+  private parseGitHubUrl(url: string): { owner: string; repo: string } {
+    const githubUrlPattern = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/?$/
+    const match = url.match(githubUrlPattern)
+
+    if (!match) {
+      throw new Error("Invalid GitHub repository URL format")
+    }
+
+    return {
+      owner: match[1],
+      repo: match[2],
+    }
+  }
+}

--- a/packages/backend/src/features/data-sources/services/github-api-service.factory.ts
+++ b/packages/backend/src/features/data-sources/services/github-api-service.factory.ts
@@ -2,6 +2,8 @@ import { GitHubApiService } from "./github-api.service"
 import { GitHubApiServiceStub } from "./github-api-service.stub"
 import type { GitHubApiServiceInterface } from "./interfaces/github-api-service.interface"
 
+let stubInstance: GitHubApiServiceStub | null = null
+
 /**
  * GitHub API サービスのファクトリ関数
  * 環境変数 USE_GITHUB_API_STUB に基づいてサービス実装を切り替える
@@ -12,7 +14,10 @@ export function createGitHubApiService(
   const useStub = process.env.USE_GITHUB_API_STUB === "true"
 
   if (useStub) {
-    return new GitHubApiServiceStub()
+    if (!stubInstance) {
+      stubInstance = new GitHubApiServiceStub()
+    }
+    return stubInstance
   }
 
   return new GitHubApiService(accessToken)

--- a/packages/backend/src/features/data-sources/services/github-api-service.factory.ts
+++ b/packages/backend/src/features/data-sources/services/github-api-service.factory.ts
@@ -1,0 +1,19 @@
+import { GitHubApiService } from "./github-api.service"
+import { GitHubApiServiceStub } from "./github-api-service.stub"
+import type { GitHubApiServiceInterface } from "./interfaces/github-api-service.interface"
+
+/**
+ * GitHub API サービスのファクトリ関数
+ * 環境変数 USE_GITHUB_API_STUB に基づいてサービス実装を切り替える
+ */
+export function createGitHubApiService(
+  accessToken?: string,
+): GitHubApiServiceInterface {
+  const useStub = process.env.USE_GITHUB_API_STUB === "true"
+
+  if (useStub) {
+    return new GitHubApiServiceStub()
+  }
+
+  return new GitHubApiService(accessToken)
+}

--- a/packages/backend/src/features/data-sources/services/github-api-service.stub.ts
+++ b/packages/backend/src/features/data-sources/services/github-api-service.stub.ts
@@ -1,0 +1,135 @@
+import { GitHubApiError } from "../errors"
+import type {
+  GitHubApiServiceInterface,
+  GitHubRepositoryResponse,
+} from "./interfaces/github-api-service.interface"
+
+/**
+ * GitHub API サービスのスタブ実装
+ * E2Eテストで使用し、実際のGitHub APIを呼び出さずに制御可能なレスポンスを返す
+ */
+export class GitHubApiServiceStub implements GitHubApiServiceInterface {
+  private stubResponses = new Map<string, GitHubRepositoryResponse>()
+  private errorScenarios = new Map<
+    string,
+    { status: number; message: string }
+  >()
+
+  /**
+   * リポジトリ情報を取得（スタブ実装）
+   */
+  async getRepository(
+    owner: string,
+    repo: string,
+  ): Promise<GitHubRepositoryResponse> {
+    const key = `${owner}/${repo}`
+
+    // エラーシナリオをチェック
+    if (this.errorScenarios.has(key)) {
+      const error = this.errorScenarios.get(key)!
+      throw new GitHubApiError(error.message, error.status)
+    }
+
+    // カスタムレスポンスがあるかチェック
+    if (this.stubResponses.has(key)) {
+      return this.stubResponses.get(key)!
+    }
+
+    // デフォルトレスポンス生成
+    return this.generateDefaultResponse(owner, repo)
+  }
+
+  /**
+   * 特定のリポジトリに対するスタブレスポンスを設定
+   */
+  setStubResponse(key: string, response: GitHubRepositoryResponse): void {
+    this.stubResponses.set(key, response)
+  }
+
+  /**
+   * 特定のリポジトリに対するエラーシナリオを設定
+   */
+  setErrorScenario(
+    key: string,
+    error: { status: number; message: string },
+  ): void {
+    this.errorScenarios.set(key, error)
+  }
+
+  /**
+   * 全てのスタブ設定をリセット
+   */
+  resetStubs(): void {
+    this.stubResponses.clear()
+    this.errorScenarios.clear()
+  }
+
+  /**
+   * デフォルトのレスポンスを生成
+   * owner/repoに基づいて一貫したレスポンスを生成する
+   */
+  private generateDefaultResponse(
+    owner: string,
+    repo: string,
+  ): GitHubRepositoryResponse {
+    const consistentId = this.generateConsistentId(owner, repo)
+
+    return {
+      id: consistentId,
+      full_name: `${owner}/${repo}`,
+      name: repo,
+      description: `Mock description for ${repo}`,
+      html_url: `https://github.com/${owner}/${repo}`,
+      private: false,
+      language: this.detectLanguage(repo),
+      stargazers_count: Math.floor((consistentId % 10000) + 1000), // 1000-10999の範囲
+      forks_count: Math.floor((consistentId % 1000) + 100), // 100-1099の範囲
+      open_issues_count: Math.floor((consistentId % 100) + 10), // 10-109の範囲
+      fork: false,
+    }
+  }
+
+  /**
+   * owner/repoの組み合わせから一貫したIDを生成
+   */
+  private generateConsistentId(owner: string, repo: string): number {
+    const combined = `${owner}/${repo}`
+    let hash = 0
+    for (let i = 0; i < combined.length; i++) {
+      const char = combined.charCodeAt(i)
+      hash = (hash << 5) - hash + char
+      hash = hash & hash // 32bit整数に変換
+    }
+    // 正の数にして、現実的なGitHub IDの範囲にする
+    return (Math.abs(hash) % 100000000) + 1000000 // 1000000-100999999の範囲
+  }
+
+  /**
+   * リポジトリ名から推測される言語を返す
+   */
+  private detectLanguage(repo: string): string | null {
+    const lowerRepo = repo.toLowerCase()
+
+    if (lowerRepo.includes("react") || lowerRepo.includes("next")) {
+      return "JavaScript"
+    }
+    if (lowerRepo.includes("typescript") || lowerRepo.includes("ts")) {
+      return "TypeScript"
+    }
+    if (lowerRepo.includes("python") || lowerRepo.includes("py")) {
+      return "Python"
+    }
+    if (lowerRepo.includes("java")) {
+      return "Java"
+    }
+    if (lowerRepo.includes("go") || lowerRepo.includes("golang")) {
+      return "Go"
+    }
+    if (lowerRepo.includes("rust")) {
+      return "Rust"
+    }
+
+    // デフォルト
+    return "JavaScript"
+  }
+}

--- a/packages/backend/src/features/data-sources/services/github-api.service.ts
+++ b/packages/backend/src/features/data-sources/services/github-api.service.ts
@@ -1,0 +1,55 @@
+import { Octokit } from "@octokit/rest"
+import { GitHubApiError } from "../errors"
+import type {
+  GitHubApiServiceInterface,
+  GitHubRepositoryResponse,
+} from "./interfaces/github-api-service.interface"
+
+/**
+ * GitHub API サービス
+ * Octokit を使用してGitHub API と通信
+ */
+export class GitHubApiService implements GitHubApiServiceInterface {
+  private octokit: Octokit
+
+  constructor(accessToken?: string) {
+    this.octokit = new Octokit({
+      auth: accessToken, // 未指定の場合は公開リポジトリのみアクセス可能
+    })
+  }
+
+  /**
+   * リポジトリ情報を取得
+   */
+  async getRepository(
+    owner: string,
+    repo: string,
+  ): Promise<GitHubRepositoryResponse> {
+    try {
+      const response = await this.octokit.rest.repos.get({
+        owner,
+        repo,
+      })
+
+      return response.data as GitHubRepositoryResponse
+    } catch (error: unknown) {
+      const apiError = error as { status?: number; message?: string }
+      if (apiError.status === 404) {
+        throw new GitHubApiError(
+          `Repository ${owner}/${repo} not found or not accessible`,
+          404,
+        )
+      }
+      if (apiError.status === 403) {
+        throw new GitHubApiError(
+          "GitHub API rate limit exceeded or forbidden",
+          403,
+        )
+      }
+      throw new GitHubApiError(
+        `GitHub API error: ${apiError.message || "Unknown error"}`,
+        apiError.status,
+      )
+    }
+  }
+}

--- a/packages/backend/src/features/data-sources/services/index.ts
+++ b/packages/backend/src/features/data-sources/services/index.ts
@@ -1,0 +1,3 @@
+// データソースサービスのエクスポート
+export * from "./data-source-creation.service"
+export * from "./github-api.service"

--- a/packages/backend/src/features/data-sources/services/interfaces/github-api-service.interface.ts
+++ b/packages/backend/src/features/data-sources/services/interfaces/github-api-service.interface.ts
@@ -1,0 +1,27 @@
+/**
+ * GitHub API レスポンスの型定義
+ */
+export type GitHubRepositoryResponse = {
+  id: number
+  full_name: string
+  name: string
+  description: string | null
+  html_url: string
+  private: boolean
+  language: string | null
+  stargazers_count: number
+  forks_count: number
+  open_issues_count: number
+  fork: boolean
+}
+
+/**
+ * GitHub API サービスのインターフェース
+ * 実装とスタブの両方でこのインターフェースを使用
+ */
+export interface GitHubApiServiceInterface {
+  /**
+   * リポジトリ情報を取得
+   */
+  getRepository(owner: string, repo: string): Promise<GitHubRepositoryResponse>
+}

--- a/packages/backend/src/test/factories.ts
+++ b/packages/backend/src/test/factories.ts
@@ -147,7 +147,7 @@ export class TestDataFactory {
     const dataSource: DataSource = {
       id: uuidv7(),
       sourceType: "github",
-      sourceId: `test_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`, // ユニークなIDを生成
+      sourceId: `test_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`, // ユニークなIDを生成
       name: "Test Repository",
       description: "A test repository",
       url: "https://github.com/test/repository",


### PR DESCRIPTION
## Summary

DataSourceCreationServiceのComponentテストにおいて、サービスクラスのモックを廃止し、実際のデータベースアクセスを使用する真のComponentテストに変更しました。

### 主な変更点

- **DataSourceCreationServiceの依存性注入対応**
  - コンストラクタにUserRepositoryとGitHubApiServiceInterfaceを追加
  - テスト時にGitHubApiServiceStubを直接注入可能に

- **Componentテストの真の実装**
  - サービスのモックを削除し、実際のサービスインスタンスを使用
  - 実際のデータベース操作を含むend-to-endテストに変更
  - GitHubApiServiceStubを同一プロセス内で直接制御

- **Auth0UserID→UUID変換ロジックの追加**
  - UserRepository.findByAuth0Id()を使用してDB制約エラーを解決
  - Auth0のUserIDからデータベースのUUIDへの適切な変換を実装

- **テストアサーションの改善**
  - モック検証から実際のレスポンスデータ検証に変更
  - データベースに実際に保存されたデータの検証を実施

### テスト結果

✅ 全131テストが成功（4テストスキップ）
✅ 実際のDBアクセスを含む真のComponentテスト動作を確認
✅ GitHubAPIスタブの直接制御によるエラーシナリオテストも正常動作

## Test plan

- [x] 既存テストの動作確認（131/131 passed）
- [x] Componentテストの原則に従った実装確認
- [x] 実際のDBアクセスの動作確認
- [x] エラーシナリオのテスト動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)