### PR TITLE
feat(CHASE-56): DataSource一覧取得API実装とルート構造の改善

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 必要に応じて以下のファイルを参照してください。
 
+## このプロジェクトの概要
+
+**IMPORTANT: このプロジェクトのゴールや何をするものかが書かれています。作業開始時は必ず参照してください。**
+
+@docs/project-overview.md
+
 ## 開発コマンド一覧
 
 @.github/instructions/dev_commands.instructions.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -2,6 +2,12 @@
 
 必要に応じて以下のファイルを参照してください。
 
+## このプロジェクトの概要
+
+**IMPORTANT: このプロジェクトのゴールや何をするものかが書かれています。作業開始時は必ず参照してください。**
+
+@docs/project-overview.md
+
 ## 開発コマンド一覧
 
 @.github/instructions/dev_commands.instructions.md

--- a/docs/task-logs/CHASE-56/data-source-list-api-plan.md
+++ b/docs/task-logs/CHASE-56/data-source-list-api-plan.md
@@ -1,0 +1,302 @@
+# CHASE-56: DataSource一覧取得API実装計画
+
+## 概要
+
+CHASE-56の一環として、DataSource一覧取得APIを実装します。
+ユーザーがWatch中のDataSourceを豊富なフィルタリング・検索・ソート機能付きで取得できるAPIを提供します。
+
+## 実装日時
+
+- **作成日**: 2025-07-09
+- **実装者**: Claude Code
+- **対応課題**: CHASE-56
+
+## 機能仕様
+
+### 1. APIエンドポイント
+
+```
+GET /data-sources
+```
+
+### 2. 認証
+
+- JWT認証必須
+- 認証されたユーザーのWatch対象DataSourceのみ取得可能
+
+### 3. クエリパラメータ
+
+| パラメータ | 型 | 必須 | デフォルト | 説明 |
+|----------|---|------|-----------|------|
+| `name` | string | × | - | データソース名での部分一致検索 |
+| `owner` | string | × | - | GitHubオーナー名での部分一致検索 |
+| `search` | string | × | - | フリーワード検索（name, description, url, fullName対象） |
+| `sourceType` | string | × | - | データソースタイプ（github, npm等） |
+| `isPrivate` | boolean | × | - | プライベート/パブリック絞り込み |
+| `language` | string | × | - | プログラミング言語での絞り込み |
+| `createdAfter` | string | × | - | 登録日（これ以降）ISO8601形式 |
+| `createdBefore` | string | × | - | 登録日（これ以前）ISO8601形式 |
+| `updatedAfter` | string | × | - | 更新日（これ以降）ISO8601形式 |
+| `updatedBefore` | string | × | - | 更新日（これ以前）ISO8601形式 |
+| `sortBy` | string | × | createdAt | ソート基準（name, createdAt, updatedAt, addedAt, starsCount） |
+| `sortOrder` | string | × | desc | ソート順（asc, desc） |
+| `page` | number | × | 1 | ページ番号（1ベース） |
+| `perPage` | number | × | 20 | 1ページあたりの件数（1-100） |
+
+### 4. レスポンス仕様
+
+#### 正常レスポンス（200）
+
+```json
+{
+  "success": true,
+  "data": {
+    "items": [
+      {
+        "dataSource": {
+          "id": "uuid",
+          "sourceType": "github",
+          "sourceId": "123456789",
+          "name": "React",
+          "description": "A declarative, efficient, and flexible JavaScript library for building user interfaces.",
+          "url": "https://github.com/facebook/react",
+          "isPrivate": false,
+          "createdAt": "2024-07-08T10:00:00.000Z",
+          "updatedAt": "2024-07-08T10:00:00.000Z"
+        },
+        "repository": {
+          "id": "uuid",
+          "dataSourceId": "uuid",
+          "githubId": 10270250,
+          "fullName": "facebook/react",
+          "owner": "facebook",
+          "language": "JavaScript",
+          "starsCount": 230000,
+          "forksCount": 47000,
+          "openIssuesCount": 1500,
+          "isFork": false,
+          "createdAt": "2024-07-08T10:00:00.000Z",
+          "updatedAt": "2024-07-08T10:00:00.000Z"
+        },
+        "userWatch": {
+          "id": "uuid",
+          "userId": "uuid",
+          "dataSourceId": "uuid",
+          "notificationEnabled": true,
+          "watchReleases": true,
+          "watchIssues": false,
+          "watchPullRequests": false,
+          "addedAt": "2024-07-08T10:00:00.000Z"
+        }
+      }
+    ],
+    "pagination": {
+      "page": 1,
+      "perPage": 20,
+      "total": 150,
+      "totalPages": 8,
+      "hasNext": true,
+      "hasPrev": false
+    }
+  }
+}
+```
+
+#### エラーレスポンス
+
+- **401 Unauthorized**: 認証エラー
+- **400 Bad Request**: 不正なパラメータ
+- **500 Internal Server Error**: サーバーエラー
+
+## 実装方針
+
+### 1. アーキテクチャ
+
+既存のDataSource登録APIと同じアーキテクチャパターンを踏襲し、CQRS的な設計を採用：
+- **Domain層**: 型定義（CQRSのQuery側専用型も含む）
+- **Repository層**: データアクセス
+- **Service層**: ビジネスロジック
+- **Presentation層**: API定義
+
+### 2. CQRS設計の採用
+
+#### 設計判断の理由
+データソース一覧取得は、既存のCRUD操作とは異なる要求を持つため、CQRS（Command Query Responsibility Segregation）的なアプローチを採用しました。
+
+#### 新しいドメイン型の定義
+
+**新規ファイル**: `domain/data-source-list.ts`
+
+```typescript
+// 検索結果用のリポジトリ型（ownerフィールドを追加）
+export type DataSourceListRepository = Repository & {
+  owner: string // fullNameから抽出したオーナー名
+}
+
+// 検索結果用の複合型（CQRS Query側）
+export type DataSourceListItem = {
+  dataSource: DataSource
+  repository: DataSourceListRepository
+  userWatch: UserWatch
+}
+
+// 検索結果とページネーション情報
+export type DataSourceListResult = {
+  items: DataSourceListItem[]
+  total: number
+}
+
+// 検索フィルター型
+export type DataSourceListFilters = {
+  name?: string
+  owner?: string
+  search?: string
+  // ... その他のフィルター
+}
+```
+
+#### 設計上の利点
+
+1. **責任分離**: 検索専用の型により、CRUDと検索の責任が明確に分離
+2. **拡張性**: 将来的に検索結果に追加情報が必要になった場合に対応しやすい
+3. **型安全性**: 検索結果専用の型により、コンパイル時の型チェックが強化
+4. **利便性**: `owner`フィールドの追加により、フロントエンドでの使用が容易
+
+### 3. データベース設計
+
+#### 主要なテーブル
+
+- `dataSources`: データソース基本情報
+- `repositories`: GitHubリポジトリ固有情報
+- `userWatches`: ユーザーのWatch設定
+
+#### JOIN戦略
+
+```sql
+SELECT 
+  ds.*,
+  r.*,
+  uw.*
+FROM dataSources ds
+INNER JOIN repositories r ON ds.id = r.dataSourceId
+INNER JOIN userWatches uw ON ds.id = uw.dataSourceId
+WHERE uw.userId = ?
+```
+
+### 4. フィルタリング実装
+
+#### 動的WHERE条件
+
+- `name`: `ds.name ILIKE %?%`
+- `owner`: `SPLIT_PART(r.fullName, '/', 1) ILIKE %?%`
+- `search`: `(ds.name ILIKE %?% OR ds.description ILIKE %?% OR ds.url ILIKE %?% OR r.fullName ILIKE %?%)`
+- `sourceType`: `ds.sourceType = ?`
+- `isPrivate`: `ds.isPrivate = ?`
+- `language`: `r.language = ?`
+- `createdAfter`: `ds.createdAt >= ?`
+- `createdBefore`: `ds.createdAt <= ?`
+- `updatedAfter`: `ds.updatedAt >= ?`
+- `updatedBefore`: `ds.updatedAt <= ?`
+
+#### ソート実装
+
+- `name`: `ds.name`
+- `createdAt`: `ds.createdAt`
+- `updatedAt`: `ds.updatedAt`
+- `addedAt`: `uw.addedAt`
+- `starsCount`: `r.starsCount`
+
+### 5. パフォーマンス最適化
+
+#### インデックス活用
+
+- 既存のインデックスを活用
+- 必要に応じて複合インデックスの検討
+
+#### ページネーション
+
+- `LIMIT`/`OFFSET`による実装
+- 将来的にカーソルベースページネーションの検討
+
+## 実装ファイル
+
+### 新規作成
+
+1. **`data-source-list-request.schema.ts`**
+   - クエリパラメータのZodスキーマ定義
+
+2. **`data-source-list-response.schema.ts`**
+   - レスポンス形式のZodスキーマ定義
+
+3. **`data-source-list.service.ts`**
+   - ビジネスロジック実装
+
+4. **`data-source-list.service.test.ts`**
+   - サービス層のユニットテスト
+
+### 更新
+
+1. **`data-source.repository.ts`**
+   - `findByUserWithFilters()`メソッド追加
+
+2. **`routes/data-sources/index.ts`**
+   - GET /data-sources エンドポイント追加
+
+3. **`routes/data-sources/__tests__/index.test.ts`**
+   - エンドポイントのテスト追加
+
+## 実装手順
+
+### Phase 1: 設計・計画 ✅
+1. [x] 作業ログ作成
+2. [ ] リクエストスキーマ定義
+3. [ ] レスポンススキーマ定義
+
+### Phase 2: データアクセス層
+4. [ ] データベーススキーマ分析
+5. [ ] リポジトリメソッド実装
+6. [ ] リポジトリテスト実装
+
+### Phase 3: ビジネスロジック層（相談タイミング）
+7. [ ] サービス実装
+8. [ ] サービステスト実装
+
+### Phase 4: プレゼンテーション層
+9. [ ] APIルート実装
+10. [ ] APIテスト実装
+
+### Phase 5: 動作確認
+11. [ ] 手動テスト
+12. [ ] パフォーマンステスト
+
+## 考慮事項
+
+### セキュリティ
+
+- JWT認証による認可
+- SQLインジェクション対策（Drizzle ORM使用）
+- パラメータ検証（Zod使用）
+
+### パフォーマンス
+
+- インデックス活用
+- 効率的なJOINクエリ
+- 適切なページネーション
+
+### 拡張性
+
+- 新データソースタイプ対応
+- フィルタ条件追加
+- ソート軸追加
+
+## 進捗状況
+
+- [x] 実装計画策定
+- [ ] 実装開始
+- [ ] 実装完了
+- [ ] テスト完了
+- [ ] 動作確認完了
+
+## 備考
+
+このファイルは実装過程で適宜更新され、進捗状況や発生した問題、解決策などを記録するために使用されます。

--- a/packages/backend/src/features/data-sources/domain/data-source-list.ts
+++ b/packages/backend/src/features/data-sources/domain/data-source-list.ts
@@ -1,0 +1,55 @@
+import type { DataSource } from "./data-source"
+import type { Repository } from "./repository"
+import type { UserWatch } from "./user-watch"
+
+/**
+ * 検索結果用のリポジトリ型（CQRS Query側）
+ * ownerフィールドを追加して利便性を向上
+ */
+export type DataSourceListRepository = Repository & {
+  owner: string // fullNameから抽出したオーナー名
+}
+
+/**
+ * 検索結果用の複合型（CQRS Query側）
+ * データソース、リポジトリ、ユーザーウォッチの情報を統合
+ */
+export type DataSourceListItem = {
+  dataSource: DataSource
+  repository: DataSourceListRepository
+  userWatch: UserWatch
+}
+
+/**
+ * 検索結果とページネーション情報
+ */
+export type DataSourceListResult = {
+  items: DataSourceListItem[]
+  total: number
+}
+
+/**
+ * 検索フィルター型
+ * データソース一覧検索で使用可能な全てのフィルタリング条件を定義
+ */
+export type DataSourceListFilters = {
+  // 検索・フィルタリング
+  name?: string
+  owner?: string
+  search?: string
+  sourceType?: string
+  isPrivate?: boolean
+  language?: string
+  createdAfter?: Date
+  createdBefore?: Date
+  updatedAfter?: Date
+  updatedBefore?: Date
+  
+  // ソート
+  sortBy?: "name" | "createdAt" | "updatedAt" | "addedAt" | "starsCount"
+  sortOrder?: "asc" | "desc"
+  
+  // ページネーション
+  offset?: number
+  limit?: number
+}

--- a/packages/backend/src/features/data-sources/domain/index.ts
+++ b/packages/backend/src/features/data-sources/domain/index.ts
@@ -2,3 +2,4 @@
 export * from "./data-source"
 export * from "./repository"
 export * from "./user-watch"
+export * from "./data-source-list"

--- a/packages/backend/src/features/data-sources/index.ts
+++ b/packages/backend/src/features/data-sources/index.ts
@@ -4,7 +4,7 @@ import {
   UserWatchRepository,
 } from "./repositories"
 import { UserRepository } from "../user/repositories/user.repository"
-import { DataSourceCreationService } from "./services"
+import { DataSourceCreationService, DataSourceListService } from "./services"
 import { createDataSourcePresentationRoutes } from "./presentation"
 
 /**
@@ -28,9 +28,15 @@ const dataSourceCreationService = new DataSourceCreationService(
   userRepository,
 )
 
+const dataSourceListService = new DataSourceListService(
+  dataSourceRepository,
+  userRepository,
+)
+
 // 依存性を注入してルーターを構築
 const dataSourceRoutes = createDataSourcePresentationRoutes(
   dataSourceCreationService,
+  dataSourceListService,
 )
 
 export default dataSourceRoutes

--- a/packages/backend/src/features/data-sources/presentation/routes.ts
+++ b/packages/backend/src/features/data-sources/presentation/routes.ts
@@ -1,5 +1,8 @@
 import { OpenAPIHono } from "@hono/zod-openapi"
-import type { DataSourceCreationService } from "../services"
+import type {
+  DataSourceCreationService,
+  DataSourceListService,
+} from "../services"
 import { createDataSourceRoutes } from "./routes/data-sources"
 
 /**
@@ -7,11 +10,15 @@ import { createDataSourceRoutes } from "./routes/data-sources"
  */
 export function createDataSourcePresentationRoutes(
   dataSourceCreationService: DataSourceCreationService,
+  dataSourceListService: DataSourceListService,
 ) {
   const app = new OpenAPIHono()
 
   // /data-sources 配下のルートを登録
-  app.route("/data-sources", createDataSourceRoutes(dataSourceCreationService))
+  app.route(
+    "/data-sources",
+    createDataSourceRoutes(dataSourceCreationService, dataSourceListService),
+  )
 
   return app
 }

--- a/packages/backend/src/features/data-sources/presentation/routes/data-sources/index.ts
+++ b/packages/backend/src/features/data-sources/presentation/routes/data-sources/index.ts
@@ -1,54 +1,173 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi"
 import { requireAuth } from "../../../../auth/middleware/jwt-auth.middleware"
-import type { DataSourceCreationService } from "../../../services"
+import type { DataSourceCreationService, DataSourceListService } from "../../../services"
 import {
   createDataSourceRequestSchema,
   createDataSourceResponseSchema,
+  dataSourceListRequestSchema,
+  dataSourceListResponseSchema,
   dataSourceErrorResponseSchemaDefinition,
 } from "../../schemas"
 import { handleDataSourceError } from "../../shared/error-handling"
-
-/**
- * POST /data-sources ルート定義
- */
-const createDataSourceRoute = createRoute({
-  method: "post",
-  path: "/",
-  summary: "データソース登録",
-  description:
-    "GitHubリポジトリをデータソースとして登録し、ユーザーの監視対象に追加します",
-  tags: ["DataSources"],
-  security: [{ Bearer: [] }],
-  request: {
-    body: {
-      content: {
-        "application/json": {
-          schema: createDataSourceRequestSchema,
-        },
-      },
-      description: "データソース作成リクエスト",
-    },
-  },
-  responses: {
-    201: {
-      content: {
-        "application/json": {
-          schema: createDataSourceResponseSchema,
-        },
-      },
-      description: "データソースが正常に作成されました",
-    },
-    ...dataSourceErrorResponseSchemaDefinition,
-  },
-})
 
 /**
  * データソースルートファクトリー
  */
 export function createDataSourceRoutes(
   dataSourceCreationService: DataSourceCreationService,
+  dataSourceListService: DataSourceListService,
 ) {
   const app = new OpenAPIHono()
+
+  // ===== データソース一覧取得機能 =====
+
+  /**
+   * GET /data-sources ルート定義
+   */
+  const listDataSourcesRoute = createRoute({
+    method: "get",
+    path: "/",
+    summary: "データソース一覧取得",
+    description:
+      "ユーザーが監視中のデータソース一覧を取得します。フィルタリング、ソート、ページネーションに対応しています",
+    tags: ["DataSources"],
+    security: [{ Bearer: [] }],
+    request: {
+      query: dataSourceListRequestSchema,
+    },
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            schema: dataSourceListResponseSchema,
+          },
+        },
+        description: "データソース一覧が正常に取得されました",
+      },
+      ...dataSourceErrorResponseSchemaDefinition,
+    },
+  })
+
+  /**
+   * GET /data-sources - データソース一覧取得エンドポイント
+   */
+  app.openapi(listDataSourcesRoute, async (c) => {
+    try {
+      // 認証情報を取得
+      const authenticatedUser = requireAuth(c)
+      const auth0UserId = authenticatedUser.sub
+
+      // クエリパラメータを取得
+      const query = c.req.valid("query")
+
+      // サービス層でデータソース一覧を取得
+      const result = await dataSourceListService.execute({
+        userId: auth0UserId,
+        filters: {
+          name: query.name,
+          owner: query.owner,
+          search: query.search,
+          sourceType: query.sourceType,
+          isPrivate: query.isPrivate,
+          language: query.language,
+          createdAfter: query.createdAfter ? new Date(query.createdAfter) : undefined,
+          createdBefore: query.createdBefore ? new Date(query.createdBefore) : undefined,
+          updatedAfter: query.updatedAfter ? new Date(query.updatedAfter) : undefined,
+          updatedBefore: query.updatedBefore ? new Date(query.updatedBefore) : undefined,
+        },
+        page: query.page,
+        perPage: query.perPage,
+        sortBy: query.sortBy,
+        sortOrder: query.sortOrder,
+      })
+
+      // レスポンスを返す
+      return c.json(
+        {
+          success: true,
+          data: {
+            items: result.items.map((item) => ({
+              dataSource: {
+                id: item.dataSource.id,
+                sourceType: item.dataSource.sourceType,
+                sourceId: item.dataSource.sourceId,
+                name: item.dataSource.name,
+                description: item.dataSource.description,
+                url: item.dataSource.url,
+                isPrivate: item.dataSource.isPrivate,
+                createdAt: item.dataSource.createdAt.toISOString(),
+                updatedAt: item.dataSource.updatedAt.toISOString(),
+              },
+              repository: {
+                id: item.repository.id,
+                dataSourceId: item.repository.dataSourceId,
+                githubId: item.repository.githubId,
+                fullName: item.repository.fullName,
+                owner: item.repository.owner,
+                language: item.repository.language,
+                starsCount: item.repository.starsCount,
+                forksCount: item.repository.forksCount,
+                openIssuesCount: item.repository.openIssuesCount,
+                isFork: item.repository.isFork,
+                createdAt: item.repository.createdAt.toISOString(),
+                updatedAt: item.repository.updatedAt.toISOString(),
+              },
+              userWatch: {
+                id: item.userWatch.id,
+                userId: item.userWatch.userId,
+                dataSourceId: item.userWatch.dataSourceId,
+                notificationEnabled: item.userWatch.notificationEnabled,
+                watchReleases: item.userWatch.watchReleases,
+                watchIssues: item.userWatch.watchIssues,
+                watchPullRequests: item.userWatch.watchPullRequests,
+                addedAt: item.userWatch.addedAt.toISOString(),
+              },
+            })),
+            pagination: result.pagination,
+          },
+        },
+        200,
+      )
+    } catch (error) {
+      return handleDataSourceError(c, error, "list")
+    }
+  })
+
+  // ===== データソース作成機能 =====
+
+  /**
+   * POST /data-sources ルート定義
+   */
+  const createDataSourceRoute = createRoute({
+    method: "post",
+    path: "/",
+    summary: "データソース登録",
+    description:
+      "GitHubリポジトリをデータソースとして登録し、ユーザーの監視対象に追加します",
+    tags: ["DataSources"],
+    security: [{ Bearer: [] }],
+    request: {
+      body: {
+        content: {
+          "application/json": {
+            schema: createDataSourceRequestSchema,
+          },
+        },
+        description: "データソース作成リクエスト",
+      },
+    },
+    responses: {
+      201: {
+        content: {
+          "application/json": {
+            schema: createDataSourceResponseSchema,
+          },
+        },
+        description: "データソースが正常に作成されました",
+      },
+      ...dataSourceErrorResponseSchemaDefinition,
+    },
+  })
 
   /**
    * POST /data-sources - データソース作成エンドポイント

--- a/packages/backend/src/features/data-sources/presentation/schemas/data-source-list-request.schema.ts
+++ b/packages/backend/src/features/data-sources/presentation/schemas/data-source-list-request.schema.ts
@@ -1,0 +1,143 @@
+import { z } from "@hono/zod-openapi"
+
+/**
+ * ソート基準の定義
+ */
+export const sortBySchema = z
+  .enum(["name", "createdAt", "updatedAt", "addedAt", "starsCount"])
+  .default("createdAt")
+  .openapi({
+    description: "ソート基準",
+    example: "createdAt",
+  })
+
+/**
+ * ソート順の定義
+ */
+export const sortOrderSchema = z
+  .enum(["asc", "desc"])
+  .default("desc")
+  .openapi({
+    description: "ソート順（昇順・降順）",
+    example: "desc",
+  })
+
+/**
+ * ページネーションのページ番号
+ */
+export const pageSchema = z.coerce
+  .number()
+  .int()
+  .min(1)
+  .default(1)
+  .openapi({
+    description: "ページ番号（1ベース）",
+    example: 1,
+  })
+
+/**
+ * ページネーションの1ページあたりの件数
+ */
+export const perPageSchema = z.coerce
+  .number()
+  .int()
+  .min(1)
+  .max(100)
+  .default(20)
+  .openapi({
+    description: "1ページあたりの件数（1-100）",
+    example: 20,
+  })
+
+/**
+ * データソース一覧取得のクエリパラメータスキーマ
+ */
+export const dataSourceListRequestSchema = z
+  .object({
+    // 検索・フィルタリング
+    name: z
+      .string()
+      .optional()
+      .openapi({
+        description: "データソース名での部分一致検索",
+        example: "React",
+      }),
+    owner: z
+      .string()
+      .optional()
+      .openapi({
+        description: "GitHubオーナー名での部分一致検索",
+        example: "facebook",
+      }),
+    search: z
+      .string()
+      .optional()
+      .openapi({
+        description: "フリーワード検索（name, description, url, fullName対象）",
+        example: "javascript library",
+      }),
+    sourceType: z
+      .string()
+      .optional()
+      .openapi({
+        description: "データソースタイプでの絞り込み",
+        example: "github",
+      }),
+    isPrivate: z.coerce
+      .boolean()
+      .optional()
+      .openapi({
+        description: "プライベート/パブリック絞り込み",
+        example: false,
+      }),
+    language: z
+      .string()
+      .optional()
+      .openapi({
+        description: "プログラミング言語での絞り込み",
+        example: "JavaScript",
+      }),
+    createdAfter: z
+      .string()
+      .datetime()
+      .optional()
+      .openapi({
+        description: "登録日（これ以降）ISO8601形式",
+        example: "2024-01-01T00:00:00.000Z",
+      }),
+    createdBefore: z
+      .string()
+      .datetime()
+      .optional()
+      .openapi({
+        description: "登録日（これ以前）ISO8601形式",
+        example: "2024-12-31T23:59:59.999Z",
+      }),
+    updatedAfter: z
+      .string()
+      .datetime()
+      .optional()
+      .openapi({
+        description: "更新日（これ以降）ISO8601形式",
+        example: "2024-01-01T00:00:00.000Z",
+      }),
+    updatedBefore: z
+      .string()
+      .datetime()
+      .optional()
+      .openapi({
+        description: "更新日（これ以前）ISO8601形式",
+        example: "2024-12-31T23:59:59.999Z",
+      }),
+
+    // ソート
+    sortBy: sortBySchema,
+    sortOrder: sortOrderSchema,
+
+    // ページネーション
+    page: pageSchema,
+    perPage: perPageSchema,
+  })
+  .openapi("DataSourceListRequest")
+
+export type DataSourceListRequest = z.infer<typeof dataSourceListRequestSchema>

--- a/packages/backend/src/features/data-sources/presentation/schemas/data-source-list-response.schema.ts
+++ b/packages/backend/src/features/data-sources/presentation/schemas/data-source-list-response.schema.ts
@@ -1,0 +1,84 @@
+import { z } from "@hono/zod-openapi"
+import { dataSourceSchema, repositorySchema, userWatchSchema } from "./data-source-response.schema"
+
+/**
+ * GitHubリポジトリスキーマ（一覧用）
+ * ownerフィールドを追加
+ */
+export const repositoryListItemSchema = repositorySchema.extend({
+  owner: z.string().openapi({
+    example: "facebook",
+    description: "GitHubリポジトリのオーナー名（fullNameから抽出）",
+  }),
+}).openapi("RepositoryListItem")
+
+/**
+ * データソース一覧項目スキーマ
+ */
+export const dataSourceListItemSchema = z
+  .object({
+    dataSource: dataSourceSchema,
+    repository: repositoryListItemSchema,
+    userWatch: userWatchSchema,
+  })
+  .openapi("DataSourceListItem")
+
+/**
+ * ページネーション情報スキーマ
+ */
+export const paginationSchema = z
+  .object({
+    page: z.number().int().min(1).openapi({
+      example: 1,
+      description: "現在のページ番号（1ベース）",
+    }),
+    perPage: z.number().int().min(1).max(100).openapi({
+      example: 20,
+      description: "1ページあたりの件数",
+    }),
+    total: z.number().int().min(0).openapi({
+      example: 150,
+      description: "総件数",
+    }),
+    totalPages: z.number().int().min(0).openapi({
+      example: 8,
+      description: "総ページ数",
+    }),
+    hasNext: z.boolean().openapi({
+      example: true,
+      description: "次のページが存在するか",
+    }),
+    hasPrev: z.boolean().openapi({
+      example: false,
+      description: "前のページが存在するか",
+    }),
+  })
+  .openapi("Pagination")
+
+/**
+ * データソース一覧取得レスポンススキーマ
+ */
+export const dataSourceListResponseSchema = z
+  .object({
+    success: z.boolean().openapi({
+      example: true,
+      description: "成功フラグ",
+    }),
+    data: z
+      .object({
+        items: z.array(dataSourceListItemSchema).openapi({
+          description: "データソース一覧",
+        }),
+        pagination: paginationSchema.openapi({
+          description: "ページネーション情報",
+        }),
+      })
+      .openapi({
+        description: "レスポンスデータ",
+      }),
+  })
+  .openapi("DataSourceListResponse")
+
+export type DataSourceListResponse = z.infer<typeof dataSourceListResponseSchema>
+export type DataSourceListItem = z.infer<typeof dataSourceListItemSchema>
+export type Pagination = z.infer<typeof paginationSchema>

--- a/packages/backend/src/features/data-sources/presentation/schemas/index.ts
+++ b/packages/backend/src/features/data-sources/presentation/schemas/index.ts
@@ -1,4 +1,6 @@
 // データソーススキーマのエクスポート
 export * from "./data-source-request.schema"
 export * from "./data-source-response.schema"
+export * from "./data-source-list-request.schema"
+export * from "./data-source-list-response.schema"
 export * from "./data-source-error.schema"

--- a/packages/backend/src/features/data-sources/services/data-source-list.service.ts
+++ b/packages/backend/src/features/data-sources/services/data-source-list.service.ts
@@ -1,0 +1,90 @@
+import type { DataSourceListFilters, DataSourceListResult } from "../domain"
+import type { DataSourceRepository } from "../repositories"
+import type { UserRepository } from "../../user/repositories/user.repository"
+import { UserNotFoundError } from "../errors"
+
+/**
+ * データソース一覧取得サービスの入力DTO
+ */
+export type DataSourceListInputDto = {
+  userId: string
+  filters?: DataSourceListFilters
+  page?: number
+  perPage?: number
+  sortBy?: string
+  sortOrder?: "asc" | "desc"
+}
+
+/**
+ * データソース一覧取得サービスの出力DTO
+ */
+export type DataSourceListOutputDto = {
+  items: DataSourceListResult["items"]
+  pagination: {
+    page: number
+    perPage: number
+    total: number
+    totalPages: number
+    hasNext: boolean
+    hasPrev: boolean
+  }
+}
+
+/**
+ * データソース一覧取得サービス
+ * ユーザーがWatch中のデータソースを取得し、ページネーション情報を付与
+ */
+export class DataSourceListService {
+  constructor(
+    private dataSourceRepository: DataSourceRepository,
+    private userRepository: UserRepository,
+  ) {}
+
+  /**
+   * データソース一覧を取得
+   */
+  async execute(input: DataSourceListInputDto): Promise<DataSourceListOutputDto> {
+    // Auth0 UserIDからユーザーのDBレコードを取得
+    const user = await this.userRepository.findByAuth0Id(input.userId)
+    if (!user) {
+      throw new UserNotFoundError(input.userId)
+    }
+
+    // ページネーション計算
+    const page = input.page || 1
+    const perPage = Math.min(input.perPage || 20, 100) // 最大100件
+    const offset = (page - 1) * perPage
+
+    // フィルター条件を準備
+    const filters: DataSourceListFilters = {
+      ...input.filters,
+      offset,
+      limit: perPage,
+      sortBy: (input.sortBy as DataSourceListFilters["sortBy"]) || "createdAt",
+      sortOrder: input.sortOrder || "desc",
+    }
+
+    // データソース一覧を取得
+    const result = await this.dataSourceRepository.findByUserWithFilters(
+      user.id,
+      filters,
+    )
+
+    // ページネーション情報を計算
+    const totalPages = Math.ceil(result.total / perPage)
+    const hasNext = page < totalPages
+    const hasPrev = page > 1
+
+    return {
+      items: result.items,
+      pagination: {
+        page,
+        perPage,
+        total: result.total,
+        totalPages,
+        hasNext,
+        hasPrev,
+      },
+    }
+  }
+}

--- a/packages/backend/src/features/data-sources/services/index.ts
+++ b/packages/backend/src/features/data-sources/services/index.ts
@@ -1,3 +1,4 @@
 // データソースサービスのエクスポート
 export * from "./data-source-creation.service"
+export * from "./data-source-list.service"
 export * from "./github-api.service"


### PR DESCRIPTION
## Summary
- **新機能**: DataSource一覧取得APIを実装（GET /data-sources）
- **機能改善**: APIルート構造をコロケーション原則に従って修正
- 豊富なフィルタリング・検索・ソート機能を持つ一覧取得APIを提供

## 主な変更内容

### 🆕 新規実装
- **DataSource一覧取得API**: フィルタリング、検索、ソート、ページネーション対応
- **ドメイン層**: `DataSourceListItem`, `DataSourceListRepository` 等のCQRS Query側型定義
- **リポジトリ層**: `findByUserWithFilters()` メソッド実装
- **サービス層**: `DataSourceListService` 実装
- **スキーマ層**: リクエスト・レスポンススキーマ定義
- **テスト**: 包括的なComponent Test追加

### 🔧 構造改善
- APIルート定義とエンドポイント実装を機能単位でコロケーション
- `// ===== データソース一覧取得機能 =====` セクション追加
- `// ===== データソース作成機能 =====` セクション追加
- 保守性と可読性の向上

## API仕様
```
GET /data-sources?name=React&owner=facebook&sortBy=starsCount&sortOrder=desc&page=1&perPage=20
```

### サポートするフィルタ
- `name`: データソース名部分一致
- `owner`: GitHubオーナー名部分一致  
- `search`: フリーワード検索
- `sourceType`, `isPrivate`, `language`: 属性絞り込み
- `createdAfter`, `createdBefore`: 日付範囲絞り込み

### ソート・ページネーション
- ソート: `name`, `createdAt`, `updatedAt`, `addedAt`, `starsCount`
- ページネーション: 1-100件/ページ

## Test plan
- [x] 新規APIの包括的なComponent Test実装
- [x] リポジトリ層のUnit Test追加
- [x] 既存APIの動作確認
- [x] フィルタリング・検索・ソート機能のテスト
- [x] ページネーション機能のテスト
- [x] エラーハンドリングのテスト

🤖 Generated with [Claude Code](https://claude.ai/code)