### PR TITLE
feat: CHASE-11 Dependabot設定とGitHub Actionsハッシュベースピンニング

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,91 @@
+version: 2
+updates:
+  # GitHub Actions の依存関係監視
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    reviewers:
+      - "tri-star"
+    commit-message:
+      prefix: "feat"
+      include: "scope"
+
+  # ルートフォルダの npm 依存関係監視
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "18:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "root"
+    reviewers:
+      - "tri-star"
+    commit-message:
+      prefix: "feat"
+      include: "scope"
+
+  # Backend パッケージの依存関係監視
+  - package-ecosystem: "npm"
+    directory: "/packages/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "18:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "backend"
+    reviewers:
+      - "tri-star"
+    commit-message:
+      prefix: "feat"
+      include: "scope"
+
+  # Frontend パッケージの依存関係監視
+  - package-ecosystem: "npm"
+    directory: "/packages/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "18:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "frontend"
+    reviewers:
+      - "tri-star"
+    commit-message:
+      prefix: "feat"
+      include: "scope"
+
+  # Shared パッケージの依存関係監視
+  - package-ecosystem: "npm"
+    directory: "/packages/shared"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "18:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "shared"
+    reviewers:
+      - "tri-star"
+    commit-message:
+      prefix: "feat"
+      include: "scope"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,15 +12,15 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@36de12bed180fa130ed56a35e7344f2fa7a820ab # v4
         with:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
           cache: "pnpm"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       backend-changed: ${{ steps.changes.outputs.backend }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
@@ -52,15 +52,15 @@ jobs:
     if: needs.detect-changes.outputs.frontend-changed == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@36de12bed180fa130ed56a35e7344f2fa7a820ab # v4
         with:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
           cache: "pnpm"
@@ -97,15 +97,15 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@36de12bed180fa130ed56a35e7344f2fa7a820ab # v4
         with:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
           cache: "pnpm"
@@ -117,7 +117,7 @@ jobs:
         run: pnpm --filter backend test:coverage
 
       - name: Upload backend coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5
         with:
           files: packages/backend/coverage/lcov.info
           flags: backend
@@ -159,15 +159,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@36de12bed180fa130ed56a35e7344f2fa7a820ab # v4
         with:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
           cache: "pnpm"
@@ -176,7 +176,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -185,7 +185,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install PostgreSQL Client
-        uses: Eeems-Org/apt-cache-action@v1
+        uses: Eeems-Org/apt-cache-action@5612bff703b327e4e764d671f434a7f198c09d60 # v1
         with:
           packages: postgresql-client
 
@@ -231,7 +231,7 @@ jobs:
           APP_STAGE: development
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: playwright-report
@@ -239,7 +239,7 @@ jobs:
           retention-days: 30
 
       - name: Upload Nuxt preview log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: nuxt-preview-log

--- a/packages/backend/src/features/data-sources/presentation/routes/data-sources/__tests__/index.test.ts
+++ b/packages/backend/src/features/data-sources/presentation/routes/data-sources/__tests__/index.test.ts
@@ -955,12 +955,15 @@ describe("DataSources API - Component Test", () => {
       )
 
       // テスト用のイベントと通知を作成
-      const testEvent = await TestDataFactory.createTestEvent(testDataSource.id, {
-        eventType: "release",
-        title: "Test Release",
-        body: "Test release body",
-        version: "v1.0.0",
-      })
+      const testEvent = await TestDataFactory.createTestEvent(
+        testDataSource.id,
+        {
+          eventType: "release",
+          title: "Test Release",
+          body: "Test release body",
+          version: "v1.0.0",
+        },
+      )
 
       const testNotification = await TestDataFactory.createTestNotification(
         testUser.id,

--- a/packages/backend/src/features/data-sources/repositories/data-source.repository.ts
+++ b/packages/backend/src/features/data-sources/repositories/data-source.repository.ts
@@ -1,4 +1,15 @@
-import { eq, and, ilike, or, gte, lte, sql, asc, desc, inArray } from "drizzle-orm"
+import {
+  eq,
+  and,
+  ilike,
+  or,
+  gte,
+  lte,
+  sql,
+  asc,
+  desc,
+  inArray,
+} from "drizzle-orm"
 import { randomUUID } from "crypto"
 import { TransactionManager } from "../../../shared/db"
 import {
@@ -493,9 +504,7 @@ export class DataSourceRepository {
     )
 
     // 2. 対象データソースのイベントを削除
-    await connection.delete(events).where(
-      eq(events.dataSourceId, dataSourceId),
-    )
+    await connection.delete(events).where(eq(events.dataSourceId, dataSourceId))
 
     // 3. ユーザーのウォッチレコードを削除
     const deleteResult = await connection

--- a/packages/backend/src/test/factories.ts
+++ b/packages/backend/src/test/factories.ts
@@ -227,7 +227,17 @@ export class TestDataFactory {
       version?: string
       createdAt?: Date
     },
-  ): Promise<{ id: string; dataSourceId: string; githubEventId: string; eventType: string; title: string; body: string; version: string | null; createdAt: Date; updatedAt: Date }> {
+  ): Promise<{
+    id: string
+    dataSourceId: string
+    githubEventId: string
+    eventType: string
+    title: string
+    body: string
+    version: string | null
+    createdAt: Date
+    updatedAt: Date
+  }> {
     const now = new Date()
     const event = {
       id: uuidv7(),
@@ -258,7 +268,18 @@ export class TestDataFactory {
       isRead?: boolean
       sentAt?: Date
     },
-  ): Promise<{ id: string; userId: string; eventId: string; title: string; message: string; notificationType: string; isRead: boolean; sentAt: Date | null; createdAt: Date; updatedAt: Date }> {
+  ): Promise<{
+    id: string
+    userId: string
+    eventId: string
+    title: string
+    message: string
+    notificationType: string
+    isRead: boolean
+    sentAt: Date | null
+    createdAt: Date
+    updatedAt: Date
+  }> {
     const now = new Date()
     const notification = {
       id: uuidv7(),


### PR DESCRIPTION
## Summary

- Dependabot設定を追加し、GitHub Actionsをハッシュベースピンニングに変更
- セキュリティ強化と依存関係の自動管理を実現

### Dependabot設定
- `.github/dependabot.yml`を新規作成
- 監視対象：GitHub Actions、packages/backend、packages/frontend、packages/shared、ルートフォルダのnpm依存関係
- 週次実行（月曜日）、各パッケージ最大5個のPRを同時オープン
- 適切なラベル付けとレビュアー設定、conventional commitメッセージ形式

### GitHub Actionsハッシュベースピンニング
- セキュリティ強化：タグの改ざんリスクを軽減、予期しないアクションの変更を防止
- 対象アクション：actions/checkout、actions/setup-node、pnpm/action-setup、actions/cache、actions/upload-artifact、codecov/codecov-action、Eeems-Org/apt-cache-action
- 形式：`@[ハッシュ値] # [バージョン]`

## Test plan

- [x] フォーマットとリント正常完了
- [x] GitHub Actionsワークフロー構文確認
- [x] 依存関係監視設定の妥当性確認
- [ ] CI/CDパイプラインでの動作確認
- [ ] Dependabot動作確認（次回月曜日）

🤖 Generated with [Claude Code](https://claude.ai/code)