### PR TITLE
feat(CHASE-120): アクティビティ一覧・詳細取得API実装

### DIFF
--- a/docs/sow/20251005-CHASE-120.md
+++ b/docs/sow/20251005-CHASE-120.md
@@ -1,0 +1,530 @@
+# SOW: CHASE-120: アクティビティ一覧APIの追加
+
+## プロジェクト概要
+
+**課題ID**: CHASE-120
+**作成日**: 2025-10-05
+**種別**: 新機能開発
+
+## 1. 背景と目的
+
+### 背景
+
+データソース監視によって検知されたアクティビティ（GitHub PR/Issue/リリースなどの作成、更新）がDBに保存されていますが、現状ではこの情報にアクセスする手段がありません。フロントエンドからアクティビティ情報を取得・表示できるようにする必要があります。
+
+### 目的
+
+ユーザーが監視中のデータソースに関連するアクティビティを閲覧できるよう、以下のAPIエンドポイントを提供します：
+
+- ユーザーに関連する全アクティビティの一覧取得
+- 特定アクティビティの詳細取得
+- 特定データソースに関連するアクティビティの一覧取得
+
+## 2. 実装スコープ
+
+### 実装対象
+
+- `features/activities` フィーチャーの新規作成
+  - アクティビティ参照に特化した境界づけられたコンテキスト
+  - Domain層、Application層、Infrastructure層、Presentation層を含む完全なレイヤー構成
+- 3つのRESTful APIエンドポイントの実装
+- 既存の `activities` テーブルの活用（新規テーブル作成は不要）
+
+### APIエンドポイント
+
+1. `GET /api/activities` - ユーザーに関連する全アクティビティ一覧
+2. `GET /api/activities/:id` - 特定アクティビティの詳細
+3. `GET /api/data-sources/:dataSourceId/activities` - 特定データソースのアクティビティ一覧
+
+### 機能要件
+
+- ページネーション対応（デフォルト: 20件/ページ、最大: 100件/ページ）
+- フィルタリング機能
+  - アクティビティタイプ（release, issue, pull_request）
+  - ステータス（pending, completed, failed）
+  - 日付範囲（作成日、更新日）
+- ソート機能（作成日の昇順・降順、デフォルト: 作成日降順）
+- ユーザー認証必須（JWT）
+- アクセス権限チェック（ユーザーが監視中のデータソースのアクティビティのみ取得可能）
+
+### 実装除外項目
+
+- アクティビティの作成・更新・削除機能（`features/detection` の責務）
+- いいね・ブックマーク機能（将来の拡張）
+- 翻訳機能の呼び出し（検知フローの責務）
+- アクティビティの統計情報API（将来の拡張）
+
+## 3. 技術仕様
+
+### API仕様
+
+#### エンドポイント1: ユーザーのアクティビティ一覧取得
+
+```
+GET /api/activities
+```
+
+##### 認証・認可
+
+- JWT認証必須
+- ユーザーが監視中のデータソースに関連するアクティビティのみ取得可能
+
+##### リクエスト仕様（クエリパラメータ）
+
+```typescript
+{
+  activityType?: "release" | "issue" | "pull_request"
+  status?: "pending" | "completed" | "failed"
+  createdAfter?: string  // ISO 8601形式
+  createdBefore?: string
+  updatedAfter?: string
+  updatedBefore?: string
+  page?: number          // デフォルト: 1
+  perPage?: number       // デフォルト: 20, 最大: 100
+  sortBy?: "createdAt" | "updatedAt"  // デフォルト: "createdAt"
+  sortOrder?: "asc" | "desc"          // デフォルト: "desc"
+}
+```
+
+##### レスポンス仕様
+
+```typescript
+{
+  success: true,
+  data: {
+    items: Array<{
+      id: string
+      dataSource: {
+        id: string
+        name: string
+        url: string
+      }
+      activityType: ActivityType  // "release" | "issue" | "pull_request"
+      title: string
+      body: string
+      version: string | null
+      status: ActivityStatus  // "pending" | "completed" | "failed"
+      createdAt: string  // ISO 8601
+      updatedAt: string
+    }>
+    pagination: {
+      currentPage: number
+      perPage: number
+      totalItems: number
+      totalPages: number
+    }
+  }
+}
+```
+
+#### エンドポイント2: アクティビティ詳細取得
+
+```
+GET /api/activities/:id
+```
+
+##### 認証・認可
+
+- JWT認証必須
+- ユーザーが監視中のデータソースに関連するアクティビティのみ取得可能
+- 他ユーザーのアクティビティに対するアクセスは404エラーで拒否
+
+##### リクエスト仕様
+
+- パスパラメータ: `id` (UUID)
+
+##### レスポンス仕様
+
+```typescript
+{
+  success: true,
+  data: {
+    id: string
+    dataSource: {
+      id: string
+      name: string
+      description: string
+      url: string
+    }
+    activityType: ActivityType  // "release" | "issue" | "pull_request"
+    title: string
+    body: string
+    version: string | null
+    status: ActivityStatus  // "pending" | "completed" | "failed"
+    statusDetail: string | null
+    createdAt: string  // ISO 8601
+    updatedAt: string
+  }
+}
+```
+
+#### エンドポイント3: データソース別アクティビティ一覧取得
+
+```
+GET /api/data-sources/:dataSourceId/activities
+```
+
+##### 認証・認可
+
+- JWT認証必須
+- ユーザーが監視中のデータソースのアクティビティのみ取得可能
+- 監視していないデータソースへのアクセスは404エラーで拒否
+
+##### リクエスト仕様
+
+- パスパラメータ: `dataSourceId` (UUID)
+- クエリパラメータ: エンドポイント1と同様
+
+##### レスポンス仕様
+
+- エンドポイント1と同様
+
+### データベース操作
+
+#### 参照テーブル
+
+- **`activities`テーブル**: アクティビティ情報の取得
+- **`data_sources`テーブル**: データソース情報の結合
+- **`user_watches`テーブル**: ユーザーのアクセス権限チェック
+
+#### 主要クエリパターン
+
+1. **ユーザーのアクティビティ一覧取得**
+   ```sql
+   SELECT a.*, ds.*
+   FROM activities a
+   INNER JOIN data_sources ds ON a.data_source_id = ds.id
+   INNER JOIN user_watches uw ON ds.id = uw.data_source_id
+   WHERE uw.user_id = :userId
+   -- フィルタ条件
+   ORDER BY a.created_at DESC
+   LIMIT :perPage OFFSET :offset
+   ```
+
+2. **アクティビティ詳細取得（権限チェック付き）**
+   ```sql
+   SELECT a.*, ds.*
+   FROM activities a
+   INNER JOIN data_sources ds ON a.data_source_id = ds.id
+   INNER JOIN user_watches uw ON ds.id = uw.data_source_id
+   WHERE a.id = :activityId AND uw.user_id = :userId
+   ```
+
+3. **データソース別アクティビティ一覧取得（権限チェック付き）**
+   ```sql
+   SELECT a.*, ds.*
+   FROM activities a
+   INNER JOIN data_sources ds ON a.data_source_id = ds.id
+   INNER JOIN user_watches uw ON ds.id = uw.data_source_id
+   WHERE ds.id = :dataSourceId AND uw.user_id = :userId
+   -- フィルタ条件
+   ORDER BY a.created_at DESC
+   LIMIT :perPage OFFSET :offset
+   ```
+
+### アーキテクチャ設計
+
+`features/activities` フィーチャーとして新規作成し、以下のレイヤー構成を採用：
+
+#### Domain層
+
+- **`activity.ts`**: アクティビティのエンティティ型定義
+  - `Activity` 型（既存の `features/detection/domain/activity.ts` を参考に、参照用に最適化）
+  - `ActivityId` ブランド型
+  - `ActivityType`, `ActivityStatus` 列挙型（既存と共通化を検討）
+  - データソース情報を含む複合型 `ActivityWithDataSource`
+
+#### Domain/Repositories層
+
+- **`activity.repository.ts`**: リポジトリインターフェース
+  - `findByUserId`: ユーザーに関連するアクティビティ一覧取得
+  - `findById`: ID指定でのアクティビティ詳細取得（権限チェック付き）
+  - `findByDataSourceId`: データソースID指定でのアクティビティ一覧取得（権限チェック付き）
+  - `countByUserId`: 総件数取得（ページネーション用）
+  - `countByDataSourceId`: データソース別総件数取得
+
+#### Application/Use-cases層
+
+- **`list-user-activities.use-case.ts`**: ユーザーのアクティビティ一覧取得
+- **`get-activity-detail.use-case.ts`**: アクティビティ詳細取得
+- **`list-data-source-activities.use-case.ts`**: データソース別アクティビティ一覧取得
+
+#### Infrastructure/Repositories層
+
+- **`drizzle-activity.repository.ts`**: Drizzle ORM実装
+  - 既存の `features/detection/infra/repositories/drizzle-activity.repository.ts` とは別実装
+  - 参照特化のクエリ最適化（JOIN、フィルタリング）
+
+#### Presentation層
+
+- **`presentation/schemas/`**
+  - `activity-list-request.schema.ts`: 一覧取得リクエストのZodスキーマ
+  - `activity-list-response.schema.ts`: 一覧取得レスポンスのZodスキーマ
+  - `activity-detail-response.schema.ts`: 詳細取得レスポンスのZodスキーマ
+
+- **`presentation/routes/activities/index.ts`**: アクティビティルート
+  - `GET /` - ユーザーのアクティビティ一覧
+  - `GET /:id` - アクティビティ詳細
+
+- **`presentation/routes/data-sources/index.ts`**: データソースルート（既存に追加）
+  - `GET /:dataSourceId/activities` - データソース別アクティビティ一覧
+
+- **`presentation/shared/error-handling.ts`**: 共通エラーハンドリング
+
+#### 公開API
+
+- **`index.ts`**: 他フィーチャーへの公開インターフェース
+  - 現時点では公開不要（内部完結）
+
+## 4. 実装ファイル一覧
+
+### 新規作成ファイル
+
+#### Domain層
+
+1. **`packages/backend/src/features/activities/domain/activity.ts`**
+   - アクティビティのエンティティ型定義
+   - Brand型ID定義
+   - 列挙型定義
+
+2. **`packages/backend/src/features/activities/domain/repositories/activity.repository.ts`**
+   - リポジトリインターフェース定義
+
+#### Application層
+
+3. **`packages/backend/src/features/activities/application/use-cases/list-user-activities.use-case.ts`**
+   - ユーザーのアクティビティ一覧取得ロジック
+
+4. **`packages/backend/src/features/activities/application/use-cases/get-activity-detail.use-case.ts`**
+   - アクティビティ詳細取得ロジック
+
+5. **`packages/backend/src/features/activities/application/use-cases/list-data-source-activities.use-case.ts`**
+   - データソース別アクティビティ一覧取得ロジック
+
+6. **`packages/backend/src/features/activities/application/use-cases/index.ts`**
+   - ユースケースのバレルファイル
+
+#### Infrastructure層
+
+7. **`packages/backend/src/features/activities/infra/repositories/drizzle-activity.repository.ts`**
+   - Drizzle ORM実装
+
+#### Presentation層
+
+8. **`packages/backend/src/features/activities/presentation/schemas/activity-list-request.schema.ts`**
+   - 一覧取得リクエストスキーマ
+
+9. **`packages/backend/src/features/activities/presentation/schemas/activity-list-response.schema.ts`**
+   - 一覧取得レスポンススキーマ
+
+10. **`packages/backend/src/features/activities/presentation/schemas/activity-detail-response.schema.ts`**
+    - 詳細取得レスポンススキーマ
+
+11. **`packages/backend/src/features/activities/presentation/schemas/index.ts`**
+    - スキーマのバレルファイル
+
+12. **`packages/backend/src/features/activities/presentation/shared/error-handling.ts`**
+    - 共通エラーハンドリング
+
+13. **`packages/backend/src/features/activities/presentation/routes/activities/index.ts`**
+    - アクティビティルート定義
+
+14. **`packages/backend/src/features/activities/presentation/routes/activities/__tests__/index.test.ts`**
+    - アクティビティルートのコンポーネントテスト
+
+#### その他
+
+15. **`packages/backend/src/features/activities/index.ts`**
+    - フィーチャー公開APIのバレルファイル
+
+### 更新対象ファイル
+
+1. **`packages/backend/src/app.ts`**
+   - アクティビティルートの登録
+
+2. **`packages/backend/src/features/data-sources/presentation/routes/data-sources/index.ts`**
+   - データソース別アクティビティ一覧エンドポイントの追加
+
+## 5. テスト戦略
+
+### Component Test（Presentation層）
+
+テスト配置: `packages/backend/src/features/activities/presentation/routes/activities/__tests__/index.test.ts`
+
+#### GET /api/activities
+
+- 認証済みユーザーによる正常なアクティビティ一覧取得
+- ページネーションの正常動作（page, perPage パラメータ）
+- フィルタリングの正常動作（activityType, status, 日付範囲）
+- ソート機能の正常動作（sortBy, sortOrder）
+- 未認証アクセスに対する401エラー
+- 不正なパラメータに対するバリデーションエラー（400エラー）
+- 監視中のデータソースのアクティビティのみ取得できることの確認
+
+#### GET /api/activities/:id
+
+- 認証済みユーザーによる正常なアクティビティ詳細取得
+- データソース情報が含まれることの確認
+- 監視していないデータソースのアクティビティに対する404エラー
+- 存在しないアクティビティIDに対する404エラー
+- 不正なUUID形式に対するバリデーションエラー（400エラー）
+- 未認証アクセスに対する401エラー
+
+#### GET /api/data-sources/:dataSourceId/activities
+
+- 認証済みユーザーによる正常なデータソース別アクティビティ一覧取得
+- フィルタリング・ページネーション・ソート機能の動作確認
+- 監視していないデータソースに対する404エラー
+- 存在しないデータソースIDに対する404エラー
+- 不正なパラメータに対するバリデーションエラー（400エラー）
+
+### Unit Test（Use-case層）
+
+今回は実装しない（Component Testで十分にカバー可能）
+
+### Unit Test（Repository層）
+
+今回は実装しない（データベースアクセスはComponent Testで検証）
+
+## 6. 受け入れ基準
+
+### 機能要件
+
+- [ ] `GET /api/activities` でユーザーに関連するアクティビティ一覧が取得できる
+- [ ] `GET /api/activities/:id` でアクティビティ詳細が取得できる
+- [ ] `GET /api/data-sources/:dataSourceId/activities` でデータソース別アクティビティ一覧が取得できる
+- [ ] ページネーション機能が正常に動作する（デフォルト20件、最大100件）
+- [ ] フィルタリング機能が正常に動作する（activityType, status, 日付範囲）
+- [ ] ソート機能が正常に動作する（createdAt, updatedAtの昇順・降順）
+- [ ] レスポンスにデータソース名が含まれる
+- [ ] OpenAPI仕様が正しく生成される
+
+### 非機能要件
+
+- [ ] 既存のテストが全て通る
+- [ ] 新規実装したエンドポイントのComponent Testが全て通る
+- [ ] レスポンスタイムが1秒以内（100件取得時）
+- [ ] TypeScriptの型安全性が確保されている（any型の濫用なし）
+- [ ] Zodスキーマによるランタイム型検証が実装されている
+- [ ] コードがリントエラーなく整形されている
+
+### セキュリティ要件
+
+- [ ] JWT認証による適切なアクセス制御
+- [ ] ユーザーが監視中のデータソースのアクティビティのみアクセス可能
+- [ ] 監視外データソースに対するアクセスで404エラーを返す（403ではなく情報漏洩防止）
+- [ ] SQLインジェクション対策（Drizzle ORMのパラメータバインディング）
+- [ ] XSS対策（レスポンスの適切なエスケープ）
+
+## 7. 実装手順
+
+### Phase 1: Domain層・Repository層の実装
+
+- 1-1. `features/activities/domain/activity.ts` の作成
+  - エンティティ型、Brand型ID、列挙型の定義
+- 1-2. `features/activities/domain/repositories/activity.repository.ts` の作成
+  - リポジトリインターフェースの定義
+- 1-3. `features/activities/infra/repositories/drizzle-activity.repository.ts` の作成
+  - Drizzle ORM実装
+  - JOINクエリの実装
+  - フィルタリング・ページネーション・ソート機能の実装
+
+### Phase 2: Application層の実装
+
+- 2-1. `list-user-activities.use-case.ts` の実装
+  - 入力バリデーション
+  - リポジトリ呼び出し
+  - ページネーション計算
+- 2-2. `get-activity-detail.use-case.ts` の実装
+  - 権限チェック（リポジトリ層で実施）
+  - アクティビティ存在チェック
+- 2-3. `list-data-source-activities.use-case.ts` の実装
+  - データソースアクセス権限チェック
+  - リポジトリ呼び出し
+
+### Phase 3: Presentation層の実装
+
+- 3-1. Zodスキーマの作成
+  - リクエストスキーマ（クエリパラメータ、パスパラメータ）
+  - レスポンススキーマ
+- 3-2. `presentation/routes/activities/index.ts` の実装
+  - `GET /` エンドポイント
+  - `GET /:id` エンドポイント
+  - エラーハンドリング
+- 3-3. `presentation/shared/error-handling.ts` の実装
+  - 共通エラーハンドリング関数
+- 3-4. Component Testの作成・実行
+  - 正常系・異常系の網羅的なテスト
+
+### Phase 4: 統合とデプロイ準備
+
+- 4-1. `app.ts` へのルート登録
+- 4-2. `features/data-sources` への追加エンドポイント実装
+  - `GET /data-sources/:dataSourceId/activities`
+- 4-3. 全体テストの実行
+  - 既存テストの回帰確認
+  - 新規テストの実行
+- 4-4. OpenAPI仕様の確認
+- 4-5. リントチェック・フォーマット
+
+## 8. 依存関係と前提条件
+
+### 前提条件
+
+- `activities` テーブルが既に存在し、アクティビティデータが格納されている
+- `user_watches` テーブルが既に存在し、ユーザーの監視設定が管理されている
+- JWT認証ミドルウェアが実装されている（`features/identity/middleware/jwt-auth.middleware.ts`）
+
+### 依存フィーチャー
+
+- `features/identity`: JWT認証ミドルウェア
+- `features/data-sources`: データソース情報（型定義は独自に用意）
+
+### 注意事項
+
+- `features/detection` の `Activity` 型とは別に、参照用の `Activity` 型を定義する
+  - 理由: 検知フィーチャーと参照フィーチャーで必要な情報が異なる可能性があるため
+  - 将来的に共通化する場合は `packages/shared` への移動を検討
+
+## 9. リスク・考慮事項
+
+### 技術的リスク
+
+- **パフォーマンス**: アクティビティ数が増加した場合のクエリ性能劣化
+  - 既存インデックスの活用状況確認が必要
+  - 特に `idx_activities_data_source_created` の効果的な利用
+- **データ整合性**: user_watches と activities の結合による整合性
+  - 監視解除後のアクティビティの扱い（現状は取得不可、将来的に要検討）
+- **スキーマ重複**: `features/detection` と `features/activities` での型定義重複
+  - 初期は許容し、将来的に共通化を検討
+
+### 軽減策
+
+- **パフォーマンス**
+  - Component Testで100件取得時のレスポンスタイムを計測
+  - 必要に応じてクエリのEXPLAIN ANALYZEを実施
+  - インデックスの追加が必要な場合は別途検討
+- **データ整合性**
+  - 監視解除後のアクティビティ扱いはドキュメント化（SOWに記載）
+  - 将来的な要件として「過去に監視していたアクティビティの閲覧」を検討
+- **スキーマ重複**
+  - 初期実装では各フィーチャー内で独自に型定義
+  - 安定後に `packages/shared` への共通化を検討
+
+### セキュリティ考慮事項
+
+- **情報漏洩防止**: 監視外データソースへのアクセスは403ではなく404を返す
+  - 理由: データソースの存在を外部に知らせない
+- **SQLインジェクション**: Drizzle ORMのパラメータバインディングを使用
+- **XSS**: レスポンスの適切なエスケープ（Honoが自動処理）
+
+## 10. 今後の拡張予定
+
+本SOWの範囲外ですが、将来的に以下の機能拡張を検討：
+
+- アクティビティに対するいいね・ブックマーク機能
+- アクティビティの統計情報API（タイプ別件数、ステータス別件数など）
+- 全文検索機能（タイトル・本文での検索）
+- 監視解除後のアクティビティ閲覧機能
+- アクティビティの既読・未読管理
+- リアルタイム通知との連携

--- a/docs/task-logs/CHASE-120/20251005-01-log.md
+++ b/docs/task-logs/CHASE-120/20251005-01-log.md
@@ -1,0 +1,300 @@
+# CHASE-120: アクティビティ一覧API実装 - 作業ログ
+
+## 作業概要
+
+**課題ID**: CHASE-120
+**SOW**: `docs/sow/20251005-CHASE-120.md`
+**作業日**: 2025-10-05
+
+## 実装計画
+
+### Phase 1: Domain層・Repository層の実装
+
+#### 1-1. Domain層のエンティティ型定義
+
+**ファイル**: `packages/backend/src/features/activities/domain/activity.ts`
+
+- [x] ActivityType, ActivityStatus 列挙型の定義（既存の detection と共通化を検討）
+- [x] Activity エンティティ型の定義
+- [x] ActivityId のBrand型定義
+- [x] ActivityWithDataSource 複合型の定義（データソース情報を含む）
+
+**実装方針**:
+- `features/detection/domain/activity.ts` を参考に、参照用に最適化した型を定義
+- 既存の ACTIVITY_TYPE, ACTIVITY_STATUS を再利用（将来的に packages/shared へ移動を検討）
+
+#### 1-2. Domain/Repositories層のインターフェース定義
+
+**ファイル**: `packages/backend/src/features/activities/domain/repositories/activity.repository.ts`
+
+- [x] ActivityRepository インターフェース定義
+  - [x] `findByUserId`: ユーザーに関連するアクティビティ一覧取得
+  - [x] `findById`: ID指定でのアクティビティ詳細取得（権限チェック付き）
+  - [x] `findByDataSourceId`: データソースID指定でのアクティビティ一覧取得（権限チェック付き）
+  - [x] `countByUserId`: 総件数取得（ページネーション用）
+  - [x] `countByDataSourceId`: データソース別総件数取得
+
+**入出力型の定義**:
+- フィルタリング条件: `ActivityFilterInput`
+- ページネーション: `PaginationInput`, `PaginationOutput`
+- ソート: `SortInput`
+
+#### 1-3. Infrastructure/Repositories層の実装
+
+**ファイル**: `packages/backend/src/features/activities/infra/repositories/drizzle-activity.repository.ts`
+
+- [x] DrizzleActivityRepository クラスの実装
+- [x] user_watches テーブルとのJOIN実装
+- [x] data_sources テーブルとのJOIN実装
+- [x] フィルタリング機能の実装
+  - [x] activityType でのフィルタ
+  - [x] status でのフィルタ
+  - [x] 日付範囲（createdAfter, createdBefore, updatedAfter, updatedBefore）
+- [x] ページネーション実装（LIMIT, OFFSET）
+- [x] ソート機能実装（createdAt, updatedAt の昇順・降順）
+
+**参考実装**: `features/detection/infra/repositories/drizzle-activity.repository.ts`
+
+### Phase 2: Application層の実装
+
+#### 2-1. ユースケース: ユーザーのアクティビティ一覧取得
+
+**ファイル**: `packages/backend/src/features/activities/application/use-cases/list-user-activities.use-case.ts`
+
+- [x] ListUserActivitiesUseCase クラスの実装
+- [x] 入力バリデーション（ページサイズ上限チェック等）
+- [x] ActivityRepository.findByUserId 呼び出し
+- [x] ActivityRepository.countByUserId 呼び出し
+- [x] ページネーション計算（totalPages 等）
+- [x] レスポンス整形
+
+#### 2-2. ユースケース: アクティビティ詳細取得
+
+**ファイル**: `packages/backend/src/features/activities/application/use-cases/get-activity-detail.use-case.ts`
+
+- [x] GetActivityDetailUseCase クラスの実装
+- [x] ActivityRepository.findById 呼び出し（権限チェックはリポジトリ層で実施）
+- [x] アクティビティ存在チェック（nullの場合は404エラー）
+- [x] レスポンス整形
+
+#### 2-3. ユースケース: データソース別アクティビティ一覧取得
+
+**ファイル**: `packages/backend/src/features/activities/application/use-cases/list-data-source-activities.use-case.ts`
+
+- [x] ListDataSourceActivitiesUseCase クラスの実装
+- [x] データソースアクセス権限チェック（リポジトリ層で実施）
+- [x] ActivityRepository.findByDataSourceId 呼び出し
+- [x] ActivityRepository.countByDataSourceId 呼び出し
+- [x] ページネーション計算
+- [x] レスポンス整形
+
+#### 2-4. バレルファイル
+
+**ファイル**: `packages/backend/src/features/activities/application/use-cases/index.ts`
+
+- [x] 各ユースケースの再エクスポート
+
+### Phase 3: Presentation層の実装
+
+#### 3-1. Zodスキーマの作成
+
+**ファイル**: `packages/backend/src/features/activities/presentation/schemas/activity-list-request.schema.ts`
+
+- [x] クエリパラメータのZodスキーマ定義
+  - [x] activityType（optional）
+  - [x] status（optional）
+  - [x] createdAfter, createdBefore（optional, ISO 8601）
+  - [x] updatedAfter, updatedBefore（optional, ISO 8601）
+  - [x] page（optional, default: 1）
+  - [x] perPage（optional, default: 20, max: 100）
+  - [x] sortBy（optional, default: "createdAt"）
+  - [x] sortOrder（optional, default: "desc"）
+
+**ファイル**: `packages/backend/src/features/activities/presentation/schemas/activity-list-response.schema.ts`
+
+- [x] アクティビティ一覧レスポンスのZodスキーマ定義
+  - [x] items 配列（ActivityWithDataSource型）
+  - [x] pagination オブジェクト
+
+**ファイル**: `packages/backend/src/features/activities/presentation/schemas/activity-detail-response.schema.ts`
+
+- [x] アクティビティ詳細レスポンスのZodスキーマ定義
+  - [x] Activity + DataSource 情報
+
+**ファイル**: `packages/backend/src/features/activities/presentation/schemas/index.ts`
+
+- [x] スキーマのバレルファイル
+
+#### 3-2. 共通エラーハンドリング
+
+**ファイル**: `packages/backend/src/features/activities/presentation/shared/error-handling.ts`
+
+- [x] 共通エラーハンドリング関数の実装
+  - [x] 404エラー（アクティビティ未発見、監視外データソース）
+  - [x] 400エラー（バリデーションエラー）
+  - [x] 401エラー（未認証）
+  - [x] 500エラー（サーバーエラー）
+
+#### 3-3. アクティビティルート実装
+
+**ファイル**: `packages/backend/src/features/activities/presentation/routes/activities/index.ts`
+
+- [x] GET / エンドポイント実装
+  - [x] JWT認証ミドルウェア適用
+  - [x] クエリパラメータバリデーション
+  - [x] ListUserActivitiesUseCase 呼び出し
+  - [x] レスポンス返却
+  - [x] エラーハンドリング
+
+- [x] GET /:id エンドポイント実装
+  - [x] JWT認証ミドルウェア適用
+  - [x] パスパラメータバリデーション（UUID）
+  - [x] GetActivityDetailUseCase 呼び出し
+  - [x] レスポンス返却
+  - [x] エラーハンドリング
+
+#### 3-4. Component Testの作成
+
+**ファイル**: `packages/backend/src/features/activities/presentation/routes/activities/__tests__/index.test.ts`
+
+**GET /api/activities のテストケース**:
+- [x] 認証済みユーザーによる正常なアクティビティ一覧取得
+- [x] ページネーションの正常動作
+- [x] フィルタリングの正常動作（activityType, status, 日付範囲）
+- [x] ソート機能の正常動作
+- [x] 未認証アクセスに対する401エラー
+- [x] 不正なパラメータに対するバリデーションエラー
+- [x] 監視中のデータソースのアクティビティのみ取得
+
+**GET /api/activities/:id のテストケース**:
+- [x] 認証済みユーザーによる正常なアクティビティ詳細取得
+- [x] データソース情報が含まれることの確認
+- [x] 監視していないデータソースのアクティビティに対する404エラー
+- [x] 存在しないアクティビティIDに対する404エラー
+- [x] 不正なUUID形式に対するバリデーションエラー
+- [x] 未認証アクセスに対する401エラー
+
+### Phase 4: 統合とデプロイ準備
+
+#### 4-1. app.ts へのルート登録
+
+**ファイル**: `packages/backend/src/app.ts`
+
+- [x] activities ルートのインポート
+- [x] app.route("/api", activitiesRoutes) の追加
+
+#### 4-2. data-sources へのエンドポイント追加
+
+**ファイル**: `packages/backend/src/features/data-sources/presentation/routes/data-sources/index.ts`
+
+- [x] GET /:dataSourceId/activities エンドポイント追加
+  - [x] JWT認証ミドルウェア適用
+  - [x] ListDataSourceActivitiesUseCase 呼び出し
+  - [x] エラーハンドリング
+
+**テスト**: `packages/backend/src/features/data-sources/presentation/routes/data-sources/__tests__/index.test.ts`
+
+- [x] GET /api/data-sources/:dataSourceId/activities のテストケース追加
+
+#### 4-3. フィーチャー公開API
+
+**ファイル**: `packages/backend/src/features/activities/index.ts`
+
+- [x] バレルファイル作成（現時点では公開不要、将来の拡張に備える）
+
+#### 4-4. 全体テスト
+
+- [x] 既存テストの回帰確認
+- [x] 新規テストの実行
+
+#### 4-5. OpenAPI仕様の確認
+
+- [x] /scalar エンドポイントでOpenAPI仕様書を確認
+- [x] レスポンススキーマの正確性を確認
+
+#### 4-6. リントチェック・フォーマット
+
+- [x] pnpm --filter backend lint
+- [x] pnpm --filter backend format
+- [x] pnpm --filter backend test
+
+## 作業中のメモ
+
+### 既存コードの確認結果
+
+1. **JWT認証ミドルウェア**: `features/identity/middleware/jwt-auth.middleware.ts` で提供
+   - `jwtAuth` を使用して必須認証を実装
+   - `requireAuth(c)` でユーザー情報を取得
+
+2. **既存のActivity型**: `features/detection/domain/activity.ts`
+   - ACTIVITY_TYPE, ACTIVITY_STATUS を再利用可能
+   - 参照用に最適化した型を新たに定義
+
+3. **Drizzle ORM実装パターン**: `features/detection/infra/repositories/drizzle-activity.repository.ts`
+   - TransactionManager.getConnection() でDB接続取得
+   - eq, and, desc, inArray 等のDrizzle関数を使用
+   - mapToDomain で型変換
+
+4. **ルート登録パターン**: `app.ts`
+   - app.route("/api", routes) でルート登録
+
+## 懸念事項・TODO
+
+- [ ] ACTIVITY_TYPE, ACTIVITY_STATUS を packages/shared へ移動するか検討（将来的な課題）
+- [ ] パフォーマンス計測（100件取得時のレスポンスタイム）
+- [ ] インデックスの効果確認（必要に応じてEXPLAIN ANALYZE）
+
+## 実装完了チェックリスト
+
+### 機能要件
+- [x] GET /api/activities でユーザーに関連するアクティビティ一覧が取得できる
+- [x] GET /api/activities/:id でアクティビティ詳細が取得できる
+- [x] GET /api/data-sources/:dataSourceId/activities でデータソース別アクティビティ一覧が取得できる
+- [x] ページネーション機能が正常に動作する
+- [x] フィルタリング機能が正常に動作する
+- [x] ソート機能が正常に動作する
+- [x] レスポンスにデータソース名が含まれる
+- [x] OpenAPI仕様が正しく生成される
+
+### 非機能要件
+- [x] 既存のテストが全て通る
+- [x] 新規実装したエンドポイントのComponent Testが全て通る
+- [x] TypeScriptの型安全性が確保されている
+- [x] Zodスキーマによるランタイム型検証が実装されている
+- [x] コードがリントエラーなく整形されている
+
+### セキュリティ要件
+- [x] JWT認証による適切なアクセス制御
+- [x] ユーザーが監視中のデータソースのアクティビティのみアクセス可能
+- [x] 監視外データソースに対するアクセスで404エラーを返す
+
+## 実装完了
+
+**完了日時**: 2025-10-05
+
+全ての実装とテストが完了しました。
+
+### 実装結果サマリー
+
+1. **作成したファイル数**: 約20ファイル
+   - Domain層: 2ファイル
+   - Application層: 4ファイル
+   - Infrastructure層: 1ファイル
+   - Presentation層: 10ファイル以上
+
+2. **テスト結果**:
+   - 全103テスト中103テストが成功（3テストはskip）
+   - Lint: エラーなし
+   - Format: エラーなし
+
+3. **実装した機能**:
+   - `GET /api/activities` - ユーザーのアクティビティ一覧取得
+   - `GET /api/activities/:id` - アクティビティ詳細取得
+   - `GET /api/data-sources/:dataSourceId/activities` - データソース別アクティビティ一覧取得
+
+4. **主要な技術的成果**:
+   - Clean Architectureパターンに基づいた実装
+   - Brand型による型安全性の向上
+   - Zod + OpenAPIによるランタイム型検証
+   - Repository層でのアクセス制御実装
+   - 既存コードとの適切な統合

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -5,6 +5,7 @@ import { Scalar } from "@scalar/hono-api-reference"
 import { globalJWTAuth } from "./features/identity"
 import identityRoutes from "./features/identity/presentation"
 import dataSourceRoutes from "./features/data-sources"
+import activityRoutes from "./features/activities"
 import { createE2EControlRoutes } from "./features/data-sources/presentation/routes/e2e-control"
 
 /**
@@ -43,6 +44,9 @@ export const createApp = () => {
 
   // Data Source management API routes
   app.route("/api", dataSourceRoutes)
+
+  // Activity management API routes
+  app.route("/api/activities", activityRoutes)
 
   // E2E Control API routes (only in stub mode)
   if (process.env.USE_GITHUB_API_STUB === "true") {

--- a/packages/backend/src/features/activities/application/use-cases/get-activity-detail.use-case.ts
+++ b/packages/backend/src/features/activities/application/use-cases/get-activity-detail.use-case.ts
@@ -1,0 +1,39 @@
+/**
+ * アクティビティ詳細取得ユースケース
+ */
+
+import type { ActivityRepository } from "../../domain/repositories/activity.repository"
+import type { ActivityId, ActivityDetail } from "../../domain/activity"
+
+/**
+ * ユースケース入力
+ */
+export type GetActivityDetailInput = {
+  activityId: ActivityId
+  userId: string
+}
+
+/**
+ * ユースケース出力
+ */
+export type GetActivityDetailOutput = ActivityDetail
+
+/**
+ * アクティビティ詳細取得ユースケース
+ */
+export class GetActivityDetailUseCase {
+  constructor(private readonly activityRepository: ActivityRepository) {}
+
+  async execute(
+    input: GetActivityDetailInput,
+  ): Promise<GetActivityDetailOutput | null> {
+    // アクティビティ詳細の取得（権限チェックはリポジトリ層で実施）
+    const activity = await this.activityRepository.findById(
+      input.activityId,
+      input.userId,
+    )
+
+    // アクティビティが存在しない、または権限がない場合はnullを返す
+    return activity
+  }
+}

--- a/packages/backend/src/features/activities/application/use-cases/index.ts
+++ b/packages/backend/src/features/activities/application/use-cases/index.ts
@@ -1,0 +1,7 @@
+/**
+ * アクティビティユースケースのバレルファイル
+ */
+
+export * from "./list-user-activities.use-case"
+export * from "./get-activity-detail.use-case"
+export * from "./list-data-source-activities.use-case"

--- a/packages/backend/src/features/activities/application/use-cases/list-data-source-activities.use-case.ts
+++ b/packages/backend/src/features/activities/application/use-cases/list-data-source-activities.use-case.ts
@@ -1,0 +1,100 @@
+/**
+ * データソース別アクティビティ一覧取得ユースケース
+ */
+
+import type {
+  ActivityRepository,
+  ActivityFilterInput,
+  PaginationInput,
+  SortInput,
+} from "../../domain/repositories/activity.repository"
+import type { ActivityWithDataSource } from "../../domain/activity"
+
+/**
+ * ユースケース入力
+ */
+export type ListDataSourceActivitiesInput = {
+  userId: string
+  dataSourceId: string
+  filter?: ActivityFilterInput
+  pagination?: Partial<PaginationInput>
+  sort?: Partial<SortInput>
+}
+
+/**
+ * ページネーション情報
+ */
+export type DataSourceActivitiesPaginationInfo = {
+  currentPage: number
+  perPage: number
+  totalItems: number
+  totalPages: number
+}
+
+/**
+ * ユースケース出力
+ */
+export type ListDataSourceActivitiesOutput = {
+  items: ActivityWithDataSource[]
+  pagination: DataSourceActivitiesPaginationInfo
+}
+
+/**
+ * デフォルト値
+ */
+const DEFAULT_PAGE = 1
+const DEFAULT_PER_PAGE = 20
+const MAX_PER_PAGE = 100
+const DEFAULT_SORT_BY = "createdAt"
+const DEFAULT_SORT_ORDER = "desc"
+
+/**
+ * データソース別アクティビティ一覧取得ユースケース
+ */
+export class ListDataSourceActivitiesUseCase {
+  constructor(private readonly activityRepository: ActivityRepository) {}
+
+  async execute(
+    input: ListDataSourceActivitiesInput,
+  ): Promise<ListDataSourceActivitiesOutput> {
+    // ページネーションパラメータの正規化
+    const page = input.pagination?.page ?? DEFAULT_PAGE
+    const perPage = Math.min(
+      input.pagination?.perPage ?? DEFAULT_PER_PAGE,
+      MAX_PER_PAGE,
+    )
+
+    // ソートパラメータの正規化
+    const sortBy = input.sort?.sortBy ?? DEFAULT_SORT_BY
+    const sortOrder = input.sort?.sortOrder ?? DEFAULT_SORT_ORDER
+
+    // 総件数の取得（権限チェック付き）
+    const totalItems = await this.activityRepository.countByDataSourceId(
+      input.userId,
+      input.dataSourceId,
+      input.filter,
+    )
+
+    // 総ページ数の計算
+    const totalPages = Math.ceil(totalItems / perPage)
+
+    // アクティビティ一覧の取得（権限チェック付き）
+    const items = await this.activityRepository.findByDataSourceId({
+      userId: input.userId,
+      dataSourceId: input.dataSourceId,
+      filter: input.filter,
+      pagination: { page, perPage },
+      sort: { sortBy, sortOrder },
+    })
+
+    return {
+      items,
+      pagination: {
+        currentPage: page,
+        perPage,
+        totalItems,
+        totalPages,
+      },
+    }
+  }
+}

--- a/packages/backend/src/features/activities/application/use-cases/list-user-activities.use-case.ts
+++ b/packages/backend/src/features/activities/application/use-cases/list-user-activities.use-case.ts
@@ -1,0 +1,97 @@
+/**
+ * ユーザーのアクティビティ一覧取得ユースケース
+ */
+
+import type {
+  ActivityRepository,
+  ActivityFilterInput,
+  PaginationInput,
+  SortInput,
+} from "../../domain/repositories/activity.repository"
+import type { ActivityWithDataSource } from "../../domain/activity"
+
+/**
+ * ユースケース入力
+ */
+export type ListUserActivitiesInput = {
+  userId: string
+  filter?: ActivityFilterInput
+  pagination?: Partial<PaginationInput>
+  sort?: Partial<SortInput>
+}
+
+/**
+ * ページネーション情報
+ */
+export type PaginationInfo = {
+  currentPage: number
+  perPage: number
+  totalItems: number
+  totalPages: number
+}
+
+/**
+ * ユースケース出力
+ */
+export type ListUserActivitiesOutput = {
+  items: ActivityWithDataSource[]
+  pagination: PaginationInfo
+}
+
+/**
+ * デフォルト値
+ */
+const DEFAULT_PAGE = 1
+const DEFAULT_PER_PAGE = 20
+const MAX_PER_PAGE = 100
+const DEFAULT_SORT_BY = "createdAt"
+const DEFAULT_SORT_ORDER = "desc"
+
+/**
+ * ユーザーのアクティビティ一覧取得ユースケース
+ */
+export class ListUserActivitiesUseCase {
+  constructor(private readonly activityRepository: ActivityRepository) {}
+
+  async execute(
+    input: ListUserActivitiesInput,
+  ): Promise<ListUserActivitiesOutput> {
+    // ページネーションパラメータの正規化
+    const page = input.pagination?.page ?? DEFAULT_PAGE
+    const perPage = Math.min(
+      input.pagination?.perPage ?? DEFAULT_PER_PAGE,
+      MAX_PER_PAGE,
+    )
+
+    // ソートパラメータの正規化
+    const sortBy = input.sort?.sortBy ?? DEFAULT_SORT_BY
+    const sortOrder = input.sort?.sortOrder ?? DEFAULT_SORT_ORDER
+
+    // 総件数の取得
+    const totalItems = await this.activityRepository.countByUserId(
+      input.userId,
+      input.filter,
+    )
+
+    // 総ページ数の計算
+    const totalPages = Math.ceil(totalItems / perPage)
+
+    // アクティビティ一覧の取得
+    const items = await this.activityRepository.findByUserId({
+      userId: input.userId,
+      filter: input.filter,
+      pagination: { page, perPage },
+      sort: { sortBy, sortOrder },
+    })
+
+    return {
+      items,
+      pagination: {
+        currentPage: page,
+        perPage,
+        totalItems,
+        totalPages,
+      },
+    }
+  }
+}

--- a/packages/backend/src/features/activities/domain/activity.ts
+++ b/packages/backend/src/features/activities/domain/activity.ts
@@ -1,0 +1,84 @@
+/**
+ * アクティビティ参照用のドメイン型定義
+ *
+ * features/detection とは異なり、参照（読み取り）に特化した型定義
+ */
+
+import type { Brand } from "../../../shared/types/brand"
+
+/**
+ * ActivityId のブランド型
+ */
+export type ActivityId = Brand<string, "ActivityId">
+
+export const toActivityId = (id: string): ActivityId => id as ActivityId
+
+/**
+ * アクティビティタイプ
+ * detection フィーチャーと共通の定義を使用
+ */
+export const ACTIVITY_TYPE = {
+  RELEASE: "release",
+  ISSUE: "issue",
+  PULL_REQUEST: "pull_request",
+} as const
+
+export type ActivityType = (typeof ACTIVITY_TYPE)[keyof typeof ACTIVITY_TYPE]
+
+/**
+ * アクティビティステータス
+ * detection フィーチャーと共通の定義を使用
+ */
+export const ACTIVITY_STATUS = {
+  PENDING: "pending",
+  PROCESSING: "processing",
+  COMPLETED: "completed",
+  FAILED: "failed",
+} as const
+
+export type ActivityStatus =
+  (typeof ACTIVITY_STATUS)[keyof typeof ACTIVITY_STATUS]
+
+/**
+ * アクティビティエンティティ（参照用）
+ */
+export type Activity = {
+  id: ActivityId
+  dataSourceId: string
+  activityType: ActivityType
+  title: string
+  body: string
+  version: string | null
+  status: ActivityStatus
+  statusDetail: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+/**
+ * データソース情報
+ */
+export type DataSourceInfo = {
+  id: string
+  name: string
+  description: string
+  url: string
+}
+
+/**
+ * データソース情報を含むアクティビティ（一覧取得用）
+ */
+export type ActivityWithDataSource = Activity & {
+  dataSource: {
+    id: string
+    name: string
+    url: string
+  }
+}
+
+/**
+ * データソース詳細情報を含むアクティビティ（詳細取得用）
+ */
+export type ActivityDetail = Activity & {
+  dataSource: DataSourceInfo
+}

--- a/packages/backend/src/features/activities/domain/repositories/activity.repository.ts
+++ b/packages/backend/src/features/activities/domain/repositories/activity.repository.ts
@@ -1,0 +1,104 @@
+/**
+ * アクティビティリポジトリのインターフェース定義
+ *
+ * アクティビティの参照（読み取り）操作を定義
+ */
+
+import type {
+  ActivityId,
+  ActivityType,
+  ActivityStatus,
+  ActivityWithDataSource,
+  ActivityDetail,
+} from "../activity"
+
+/**
+ * フィルタリング条件
+ */
+export type ActivityFilterInput = {
+  activityType?: ActivityType
+  status?: ActivityStatus
+  createdAfter?: Date
+  createdBefore?: Date
+  updatedAfter?: Date
+  updatedBefore?: Date
+}
+
+/**
+ * ページネーション入力
+ */
+export type PaginationInput = {
+  page: number
+  perPage: number
+}
+
+/**
+ * ソート入力
+ */
+export type SortInput = {
+  sortBy: "createdAt" | "updatedAt"
+  sortOrder: "asc" | "desc"
+}
+
+/**
+ * アクティビティ一覧取得の入力
+ */
+export type FindActivitiesInput = {
+  userId: string
+  filter?: ActivityFilterInput
+  pagination: PaginationInput
+  sort: SortInput
+}
+
+/**
+ * データソース別アクティビティ一覧取得の入力
+ */
+export type FindByDataSourceInput = {
+  userId: string
+  dataSourceId: string
+  filter?: ActivityFilterInput
+  pagination: PaginationInput
+  sort: SortInput
+}
+
+/**
+ * アクティビティリポジトリインターフェース
+ */
+export interface ActivityRepository {
+  /**
+   * ユーザーに関連するアクティビティ一覧を取得
+   * ユーザーが監視中のデータソースに関連するアクティビティのみ取得
+   */
+  findByUserId(input: FindActivitiesInput): Promise<ActivityWithDataSource[]>
+
+  /**
+   * ユーザーに関連するアクティビティの総件数を取得
+   */
+  countByUserId(userId: string, filter?: ActivityFilterInput): Promise<number>
+
+  /**
+   * アクティビティ詳細を取得（権限チェック付き）
+   * ユーザーが監視中のデータソースに関連するアクティビティのみ取得
+   */
+  findById(
+    activityId: ActivityId,
+    userId: string,
+  ): Promise<ActivityDetail | null>
+
+  /**
+   * データソース別アクティビティ一覧を取得（権限チェック付き）
+   * ユーザーが監視中のデータソースのアクティビティのみ取得
+   */
+  findByDataSourceId(
+    input: FindByDataSourceInput,
+  ): Promise<ActivityWithDataSource[]>
+
+  /**
+   * データソース別アクティビティの総件数を取得（権限チェック付き）
+   */
+  countByDataSourceId(
+    userId: string,
+    dataSourceId: string,
+    filter?: ActivityFilterInput,
+  ): Promise<number>
+}

--- a/packages/backend/src/features/activities/index.ts
+++ b/packages/backend/src/features/activities/index.ts
@@ -1,0 +1,39 @@
+/**
+ * アクティビティフィーチャーの公開API
+ */
+
+import { DrizzleActivityRepository } from "./infra/repositories/drizzle-activity.repository"
+import {
+  ListUserActivitiesUseCase,
+  GetActivityDetailUseCase,
+  ListDataSourceActivitiesUseCase,
+} from "./application/use-cases"
+import { createActivityRoutes } from "./presentation/routes/activities"
+
+// リポジトリのインスタンス化
+const activityRepository = new DrizzleActivityRepository()
+
+// ユースケースのインスタンス化
+export const listUserActivitiesUseCase = new ListUserActivitiesUseCase(
+  activityRepository,
+)
+
+export const getActivityDetailUseCase = new GetActivityDetailUseCase(
+  activityRepository,
+)
+
+export const listDataSourceActivitiesUseCase =
+  new ListDataSourceActivitiesUseCase(activityRepository)
+
+// ルートの作成
+const activityRoutes = createActivityRoutes(
+  listUserActivitiesUseCase,
+  getActivityDetailUseCase,
+)
+
+export default activityRoutes
+
+// 型定義と定数のエクスポート
+export * from "./domain/activity"
+export * from "./application/use-cases"
+export * from "./presentation/shared/error-handling"

--- a/packages/backend/src/features/activities/infra/repositories/drizzle-activity.repository.ts
+++ b/packages/backend/src/features/activities/infra/repositories/drizzle-activity.repository.ts
@@ -1,0 +1,335 @@
+/**
+ * アクティビティリポジトリのDrizzle ORM実装
+ *
+ * アクティビティの参照（読み取り）操作を実装
+ */
+
+import { eq, and, desc, asc, gte, lte, sql } from "drizzle-orm"
+import { TransactionManager } from "../../../../core/db"
+import {
+  activities,
+  dataSources,
+  userWatches,
+  users,
+} from "../../../../db/schema"
+import type {
+  ActivityRepository,
+  FindActivitiesInput,
+  FindByDataSourceInput,
+  ActivityFilterInput,
+} from "../../domain/repositories/activity.repository"
+import type {
+  ActivityId,
+  ActivityWithDataSource,
+  ActivityDetail,
+} from "../../domain/activity"
+import { toActivityId } from "../../domain/activity"
+
+/**
+ * Drizzleを使用したアクティビティリポジトリ実装
+ */
+export class DrizzleActivityRepository implements ActivityRepository {
+  /**
+   * ユーザーに関連するアクティビティ一覧を取得
+   */
+  async findByUserId(
+    input: FindActivitiesInput,
+  ): Promise<ActivityWithDataSource[]> {
+    const connection = await TransactionManager.getConnection()
+    const { userId, filter, pagination, sort } = input
+
+    // WHERE句の構築
+    const whereConditions = this.buildWhereConditions(userId, filter)
+
+    // ORDER BY句の構築
+    const orderByClause =
+      sort.sortBy === "createdAt"
+        ? sort.sortOrder === "asc"
+          ? asc(activities.createdAt)
+          : desc(activities.createdAt)
+        : sort.sortOrder === "asc"
+          ? asc(activities.updatedAt)
+          : desc(activities.updatedAt)
+
+    // OFFSET計算
+    const offset = (pagination.page - 1) * pagination.perPage
+
+    // クエリ実行
+    const results = await connection
+      .select({
+        id: activities.id,
+        dataSourceId: activities.dataSourceId,
+        activityType: activities.activityType,
+        title: activities.title,
+        body: activities.body,
+        version: activities.version,
+        status: activities.status,
+        statusDetail: activities.statusDetail,
+        createdAt: activities.createdAt,
+        updatedAt: activities.updatedAt,
+        dataSourceName: dataSources.name,
+        dataSourceUrl: dataSources.url,
+      })
+      .from(activities)
+      .innerJoin(dataSources, eq(activities.dataSourceId, dataSources.id))
+      .innerJoin(userWatches, eq(dataSources.id, userWatches.dataSourceId))
+      .innerJoin(users, eq(userWatches.userId, users.id))
+      .where(and(...whereConditions))
+      .orderBy(orderByClause)
+      .limit(pagination.perPage)
+      .offset(offset)
+
+    return results.map(this.mapToActivityWithDataSource)
+  }
+
+  /**
+   * ユーザーに関連するアクティビティの総件数を取得
+   */
+  async countByUserId(
+    userId: string,
+    filter?: ActivityFilterInput,
+  ): Promise<number> {
+    const connection = await TransactionManager.getConnection()
+
+    const whereConditions = this.buildWhereConditions(userId, filter)
+
+    const result = await connection
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(activities)
+      .innerJoin(dataSources, eq(activities.dataSourceId, dataSources.id))
+      .innerJoin(userWatches, eq(dataSources.id, userWatches.dataSourceId))
+      .innerJoin(users, eq(userWatches.userId, users.id))
+      .where(and(...whereConditions))
+
+    return result[0]?.count ?? 0
+  }
+
+  /**
+   * アクティビティ詳細を取得（権限チェック付き）
+   */
+  async findById(
+    activityId: ActivityId,
+    userId: string,
+  ): Promise<ActivityDetail | null> {
+    const connection = await TransactionManager.getConnection()
+
+    const results = await connection
+      .select({
+        id: activities.id,
+        dataSourceId: activities.dataSourceId,
+        activityType: activities.activityType,
+        title: activities.title,
+        body: activities.body,
+        version: activities.version,
+        status: activities.status,
+        statusDetail: activities.statusDetail,
+        createdAt: activities.createdAt,
+        updatedAt: activities.updatedAt,
+        dataSourceName: dataSources.name,
+        dataSourceDescription: dataSources.description,
+        dataSourceUrl: dataSources.url,
+      })
+      .from(activities)
+      .innerJoin(dataSources, eq(activities.dataSourceId, dataSources.id))
+      .innerJoin(userWatches, eq(dataSources.id, userWatches.dataSourceId))
+      .innerJoin(users, eq(userWatches.userId, users.id))
+      .where(and(eq(activities.id, activityId), eq(users.auth0UserId, userId)))
+
+    if (results.length === 0) {
+      return null
+    }
+
+    return this.mapToActivityDetail(results[0])
+  }
+
+  /**
+   * データソース別アクティビティ一覧を取得（権限チェック付き）
+   */
+  async findByDataSourceId(
+    input: FindByDataSourceInput,
+  ): Promise<ActivityWithDataSource[]> {
+    const connection = await TransactionManager.getConnection()
+    const { userId, dataSourceId, filter, pagination, sort } = input
+
+    // WHERE句の構築（dataSourceIdを追加）
+    const whereConditions = this.buildWhereConditions(userId, filter, [
+      eq(dataSources.id, dataSourceId),
+    ])
+
+    // ORDER BY句の構築
+    const orderByClause =
+      sort.sortBy === "createdAt"
+        ? sort.sortOrder === "asc"
+          ? asc(activities.createdAt)
+          : desc(activities.createdAt)
+        : sort.sortOrder === "asc"
+          ? asc(activities.updatedAt)
+          : desc(activities.updatedAt)
+
+    // OFFSET計算
+    const offset = (pagination.page - 1) * pagination.perPage
+
+    // クエリ実行
+    const results = await connection
+      .select({
+        id: activities.id,
+        dataSourceId: activities.dataSourceId,
+        activityType: activities.activityType,
+        title: activities.title,
+        body: activities.body,
+        version: activities.version,
+        status: activities.status,
+        statusDetail: activities.statusDetail,
+        createdAt: activities.createdAt,
+        updatedAt: activities.updatedAt,
+        dataSourceName: dataSources.name,
+        dataSourceUrl: dataSources.url,
+      })
+      .from(activities)
+      .innerJoin(dataSources, eq(activities.dataSourceId, dataSources.id))
+      .innerJoin(userWatches, eq(dataSources.id, userWatches.dataSourceId))
+      .innerJoin(users, eq(userWatches.userId, users.id))
+      .where(and(...whereConditions))
+      .orderBy(orderByClause)
+      .limit(pagination.perPage)
+      .offset(offset)
+
+    return results.map(this.mapToActivityWithDataSource)
+  }
+
+  /**
+   * データソース別アクティビティの総件数を取得（権限チェック付き）
+   */
+  async countByDataSourceId(
+    userId: string,
+    dataSourceId: string,
+    filter?: ActivityFilterInput,
+  ): Promise<number> {
+    const connection = await TransactionManager.getConnection()
+
+    const whereConditions = this.buildWhereConditions(userId, filter, [
+      eq(dataSources.id, dataSourceId),
+    ])
+
+    const result = await connection
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(activities)
+      .innerJoin(dataSources, eq(activities.dataSourceId, dataSources.id))
+      .innerJoin(userWatches, eq(dataSources.id, userWatches.dataSourceId))
+      .innerJoin(users, eq(userWatches.userId, users.id))
+      .where(and(...whereConditions))
+
+    return result[0]?.count ?? 0
+  }
+
+  /**
+   * WHERE句の条件を構築
+   */
+  private buildWhereConditions(
+    userId: string,
+    filter?: ActivityFilterInput,
+    additionalConditions: ReturnType<typeof eq>[] = [],
+  ): ReturnType<typeof eq>[] {
+    const conditions: ReturnType<typeof eq>[] = [
+      eq(users.auth0UserId, userId),
+      ...additionalConditions,
+    ]
+
+    if (filter) {
+      if (filter.activityType) {
+        conditions.push(eq(activities.activityType, filter.activityType))
+      }
+      if (filter.status) {
+        conditions.push(eq(activities.status, filter.status))
+      }
+      if (filter.createdAfter) {
+        conditions.push(gte(activities.createdAt, filter.createdAfter))
+      }
+      if (filter.createdBefore) {
+        conditions.push(lte(activities.createdAt, filter.createdBefore))
+      }
+      if (filter.updatedAfter) {
+        conditions.push(gte(activities.updatedAt, filter.updatedAfter))
+      }
+      if (filter.updatedBefore) {
+        conditions.push(lte(activities.updatedAt, filter.updatedBefore))
+      }
+    }
+
+    return conditions
+  }
+
+  /**
+   * データベース結果をActivityWithDataSource型に変換
+   */
+  private mapToActivityWithDataSource(row: {
+    id: string
+    dataSourceId: string
+    activityType: string
+    title: string
+    body: string
+    version: string | null
+    status: string
+    statusDetail: string | null
+    createdAt: Date
+    updatedAt: Date
+    dataSourceName: string
+    dataSourceUrl: string
+  }): ActivityWithDataSource {
+    return {
+      id: toActivityId(row.id),
+      dataSourceId: row.dataSourceId,
+      activityType: row.activityType as ActivityWithDataSource["activityType"],
+      title: row.title,
+      body: row.body,
+      version: row.version,
+      status: row.status as ActivityWithDataSource["status"],
+      statusDetail: row.statusDetail,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      dataSource: {
+        id: row.dataSourceId,
+        name: row.dataSourceName,
+        url: row.dataSourceUrl,
+      },
+    }
+  }
+
+  /**
+   * データベース結果をActivityDetail型に変換
+   */
+  private mapToActivityDetail(row: {
+    id: string
+    dataSourceId: string
+    activityType: string
+    title: string
+    body: string
+    version: string | null
+    status: string
+    statusDetail: string | null
+    createdAt: Date
+    updatedAt: Date
+    dataSourceName: string
+    dataSourceDescription: string
+    dataSourceUrl: string
+  }): ActivityDetail {
+    return {
+      id: toActivityId(row.id),
+      dataSourceId: row.dataSourceId,
+      activityType: row.activityType as ActivityDetail["activityType"],
+      title: row.title,
+      body: row.body,
+      version: row.version,
+      status: row.status as ActivityDetail["status"],
+      statusDetail: row.statusDetail,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      dataSource: {
+        id: row.dataSourceId,
+        name: row.dataSourceName,
+        description: row.dataSourceDescription,
+        url: row.dataSourceUrl,
+      },
+    }
+  }
+}

--- a/packages/backend/src/features/activities/presentation/routes/activities/__tests__/index.test.ts
+++ b/packages/backend/src/features/activities/presentation/routes/activities/__tests__/index.test.ts
@@ -1,0 +1,457 @@
+/**
+ * アクティビティルートのComponent Test
+ */
+
+import { beforeEach, describe, expect, test } from "vitest"
+import { OpenAPIHono } from "@hono/zod-openapi"
+import { createActivityRoutes } from "../index"
+import {
+  ListUserActivitiesUseCase,
+  GetActivityDetailUseCase,
+} from "../../../../application/use-cases"
+import { DrizzleActivityRepository } from "../../../../infra/repositories/drizzle-activity.repository"
+import { setupComponentTest, TestDataFactory } from "../../../../../../test"
+import { AuthTestHelper } from "../../../../../identity/test-helpers/auth-test-helper"
+import { globalJWTAuth } from "../../../../../identity"
+import type { User } from "../../../../../identity/domain/user"
+import { db } from "../../../../../../db/connection"
+import {
+  activities,
+  dataSources,
+  userWatches,
+} from "../../../../../../db/schema"
+import { uuidv7 } from "uuidv7"
+
+describe("Activities API", () => {
+  setupComponentTest()
+
+  let app: OpenAPIHono
+  let listUserActivitiesUseCase: ListUserActivitiesUseCase
+  let getActivityDetailUseCase: GetActivityDetailUseCase
+  let testUser: User
+  let testToken: string
+  let testDataSourceId: string
+  let testActivityId: string
+
+  beforeEach(async () => {
+    AuthTestHelper.clearTestUsers()
+
+    testUser = await TestDataFactory.createTestUser("auth0|test123")
+    testToken = AuthTestHelper.createTestToken(
+      testUser.auth0UserId,
+      testUser.email,
+      testUser.name,
+    )
+
+    const activityRepository = new DrizzleActivityRepository()
+    listUserActivitiesUseCase = new ListUserActivitiesUseCase(
+      activityRepository,
+    )
+    getActivityDetailUseCase = new GetActivityDetailUseCase(activityRepository)
+
+    app = new OpenAPIHono()
+    app.use("*", globalJWTAuth)
+    app.route(
+      "/",
+      createActivityRoutes(listUserActivitiesUseCase, getActivityDetailUseCase),
+    )
+
+    // テストデータの作成
+    testDataSourceId = uuidv7()
+    await db.insert(dataSources).values({
+      id: testDataSourceId,
+      sourceType: "github_repository",
+      sourceId: "facebook/react",
+      name: "react",
+      description: "A JavaScript library for building user interfaces",
+      url: "https://github.com/facebook/react",
+      isPrivate: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    // ユーザーウォッチ設定の作成
+    await db.insert(userWatches).values({
+      id: uuidv7(),
+      userId: testUser.id,
+      dataSourceId: testDataSourceId,
+      notificationEnabled: true,
+      watchReleases: true,
+      watchIssues: true,
+      watchPullRequests: true,
+      addedAt: new Date(),
+    })
+
+    // テストアクティビティの作成
+    testActivityId = uuidv7()
+    await db.insert(activities).values({
+      id: testActivityId,
+      dataSourceId: testDataSourceId,
+      githubEventId: "github-event-1",
+      activityType: "release",
+      title: "React v18.0.0",
+      body: "Major release with new features",
+      version: "18.0.0",
+      status: "completed",
+      statusDetail: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+  })
+
+  describe("GET /activities", () => {
+    test("認証済みユーザーによる正常なアクティビティ一覧取得", async () => {
+      const res = await app.request("/", {
+        method: "GET",
+        headers: AuthTestHelper.createAuthHeaders(testToken),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.success).toBe(true)
+      expect(body.data.items).toHaveLength(1)
+      expect(body.data.items[0].id).toBe(testActivityId)
+      expect(body.data.items[0].title).toBe("React v18.0.0")
+      expect(body.data.items[0].dataSource.name).toBe("react")
+      expect(body.data.pagination).toEqual({
+        currentPage: 1,
+        perPage: 20,
+        totalItems: 1,
+        totalPages: 1,
+      })
+    })
+
+    test("ページネーションの正常動作", async () => {
+      // 追加のアクティビティを作成
+      for (let i = 0; i < 25; i++) {
+        await db.insert(activities).values({
+          id: uuidv7(),
+          dataSourceId: testDataSourceId,
+          githubEventId: `github-event-${uuidv7()}`,
+          activityType: "issue",
+          title: `Issue #${i}`,
+          body: `Description for issue ${i}`,
+          version: null,
+          status: "completed",
+          statusDetail: null,
+          createdAt: new Date(Date.now() + i * 1000),
+          updatedAt: new Date(Date.now() + i * 1000),
+        })
+      }
+
+      // 1ページ目（デフォルト20件）
+      const res1 = await app.request("/?page=1&perPage=10", {
+        method: "GET",
+        headers: AuthTestHelper.createAuthHeaders(testToken),
+      })
+
+      expect(res1.status).toBe(200)
+      const body1 = await res1.json()
+      expect(body1.data.items).toHaveLength(10)
+      expect(body1.data.pagination.currentPage).toBe(1)
+      expect(body1.data.pagination.perPage).toBe(10)
+      expect(body1.data.pagination.totalItems).toBe(26)
+      expect(body1.data.pagination.totalPages).toBe(3)
+
+      // 2ページ目
+      const res2 = await app.request("/?page=2&perPage=10", {
+        method: "GET",
+        headers: AuthTestHelper.createAuthHeaders(testToken),
+      })
+
+      expect(res2.status).toBe(200)
+      const body2 = await res2.json()
+      expect(body2.data.items).toHaveLength(10)
+      expect(body2.data.pagination.currentPage).toBe(2)
+    })
+
+    test("フィルタリングの正常動作（activityType）", async () => {
+      // issue タイプのアクティビティを追加
+      await db.insert(activities).values({
+        id: uuidv7(),
+        dataSourceId: testDataSourceId,
+        githubEventId: `github-event-${uuidv7()}`,
+        activityType: "issue",
+        title: "Bug report",
+        body: "Something is broken",
+        version: null,
+        status: "completed",
+        statusDetail: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+
+      const res = await app.request("/?activityType=release", {
+        method: "GET",
+        headers: AuthTestHelper.createAuthHeaders(testToken),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.items).toHaveLength(1)
+      expect(body.data.items[0].activityType).toBe("release")
+    })
+
+    test("フィルタリングの正常動作（status）", async () => {
+      // failed ステータスのアクティビティを追加
+      await db.insert(activities).values({
+        id: uuidv7(),
+        dataSourceId: testDataSourceId,
+        githubEventId: `github-event-${uuidv7()}`,
+        activityType: "release",
+        title: "Failed release",
+        body: "This release failed",
+        version: "19.0.0",
+        status: "failed",
+        statusDetail: "Translation failed",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+
+      const res = await app.request("/?status=completed", {
+        method: "GET",
+        headers: AuthTestHelper.createAuthHeaders(testToken),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.items).toHaveLength(1)
+      expect(body.data.items[0].status).toBe("completed")
+    })
+
+    test("フィルタリングの正常動作（日付範囲）", async () => {
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000)
+      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000)
+      const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000)
+
+      // 昨日のアクティビティ
+      await db.insert(activities).values({
+        id: uuidv7(),
+        dataSourceId: testDataSourceId,
+        githubEventId: `github-event-${uuidv7()}`,
+        activityType: "release",
+        title: "Old release",
+        body: "Old",
+        version: "1.0.0",
+        status: "completed",
+        statusDetail: null,
+        createdAt: yesterday,
+        updatedAt: yesterday,
+      })
+
+      const res = await app.request(
+        `/?createdAfter=${oneHourAgo.toISOString()}&createdBefore=${tomorrow.toISOString()}`,
+        {
+          method: "GET",
+          headers: AuthTestHelper.createAuthHeaders(testToken),
+        },
+      )
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.items).toHaveLength(1)
+      expect(body.data.items[0].title).toBe("React v18.0.0")
+    })
+
+    test("ソート機能の正常動作", async () => {
+      const now = new Date()
+
+      // 新しいアクティビティ
+      const newActivityId = uuidv7()
+      await db.insert(activities).values({
+        id: newActivityId,
+        dataSourceId: testDataSourceId,
+        githubEventId: `github-event-${uuidv7()}`,
+        activityType: "release",
+        title: "Newer release",
+        body: "Newer",
+        version: "19.0.0",
+        status: "completed",
+        statusDetail: null,
+        createdAt: new Date(now.getTime() + 10000),
+        updatedAt: new Date(now.getTime() + 10000),
+      })
+
+      // 降順（デフォルト）
+      const resDesc = await app.request("/?sortOrder=desc", {
+        method: "GET",
+        headers: AuthTestHelper.createAuthHeaders(testToken),
+      })
+
+      expect(resDesc.status).toBe(200)
+      const bodyDesc = await resDesc.json()
+      expect(bodyDesc.data.items[0].id).toBe(newActivityId)
+
+      // 昇順
+      const resAsc = await app.request("/?sortOrder=asc", {
+        method: "GET",
+        headers: AuthTestHelper.createAuthHeaders(testToken),
+      })
+
+      expect(resAsc.status).toBe(200)
+      const bodyAsc = await resAsc.json()
+      expect(bodyAsc.data.items[0].id).toBe(testActivityId)
+    })
+
+    test("未認証アクセスに対する401エラー", async () => {
+      const res = await app.request("/", {
+        method: "GET",
+      })
+
+      expect(res.status).toBe(401)
+    })
+
+    test("不正なパラメータに対するバリデーションエラー", async () => {
+      const res = await app.request("/?page=invalid", {
+        method: "GET",
+        headers: AuthTestHelper.createAuthHeaders(testToken),
+      })
+
+      expect(res.status).toBe(400)
+    })
+
+    test("監視中のデータソースのアクティビティのみ取得", async () => {
+      // 監視していないデータソースとアクティビティを作成
+      const otherDataSourceId = uuidv7()
+      await db.insert(dataSources).values({
+        id: otherDataSourceId,
+        sourceType: "github_repository",
+        sourceId: "vuejs/vue",
+        name: "vue",
+        description: "Vue.js framework",
+        url: "https://github.com/vuejs/vue",
+        isPrivate: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+
+      await db.insert(activities).values({
+        id: uuidv7(),
+        dataSourceId: otherDataSourceId,
+        githubEventId: `github-event-${uuidv7()}`,
+        activityType: "release",
+        title: "Vue v3.0.0",
+        body: "Vue 3 release",
+        version: "3.0.0",
+        status: "completed",
+        statusDetail: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+
+      const res = await app.request("/", {
+        method: "GET",
+        headers: AuthTestHelper.createAuthHeaders(testToken),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      // 監視中のデータソースのアクティビティのみ（1件）
+      expect(body.data.items).toHaveLength(1)
+      expect(body.data.items[0].dataSource.name).toBe("react")
+    })
+  })
+
+  describe("GET /activities/:id", () => {
+    test("認証済みユーザーによる正常なアクティビティ詳細取得", async () => {
+      const res = await app.request(`/${testActivityId}`, {
+        method: "GET",
+        headers: AuthTestHelper.createAuthHeaders(testToken),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.success).toBe(true)
+      expect(body.data.id).toBe(testActivityId)
+      expect(body.data.title).toBe("React v18.0.0")
+      expect(body.data.dataSource.name).toBe("react")
+      expect(body.data.dataSource.description).toBe(
+        "A JavaScript library for building user interfaces",
+      )
+    })
+
+    test("データソース情報が含まれることの確認", async () => {
+      const res = await app.request(`/${testActivityId}`, {
+        method: "GET",
+        headers: AuthTestHelper.createAuthHeaders(testToken),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.dataSource).toHaveProperty("id")
+      expect(body.data.dataSource).toHaveProperty("name")
+      expect(body.data.dataSource).toHaveProperty("description")
+      expect(body.data.dataSource).toHaveProperty("url")
+    })
+
+    test("監視していないデータソースのアクティビティに対する404エラー", async () => {
+      // 監視していないデータソースとアクティビティを作成
+      const otherDataSourceId = uuidv7()
+      await db.insert(dataSources).values({
+        id: otherDataSourceId,
+        sourceType: "github_repository",
+        sourceId: "vuejs/vue",
+        name: "vue",
+        description: "Vue.js framework",
+        url: "https://github.com/vuejs/vue",
+        isPrivate: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+
+      const otherActivityId = uuidv7()
+      await db.insert(activities).values({
+        id: otherActivityId,
+        dataSourceId: otherDataSourceId,
+        githubEventId: `github-event-${uuidv7()}`,
+        activityType: "release",
+        title: "Vue v3.0.0",
+        body: "Vue 3 release",
+        version: "3.0.0",
+        status: "completed",
+        statusDetail: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+
+      const res = await app.request(`/${otherActivityId}`, {
+        method: "GET",
+        headers: AuthTestHelper.createAuthHeaders(testToken),
+      })
+
+      expect(res.status).toBe(404)
+      const body = await res.json()
+      expect(body.success).toBe(false)
+    })
+
+    test("存在しないアクティビティIDに対する404エラー", async () => {
+      const nonExistentId = uuidv7()
+
+      const res = await app.request(`/${nonExistentId}`, {
+        method: "GET",
+        headers: AuthTestHelper.createAuthHeaders(testToken),
+      })
+
+      expect(res.status).toBe(404)
+      const body = await res.json()
+      expect(body.success).toBe(false)
+    })
+
+    test("不正なUUID形式に対するバリデーションエラー", async () => {
+      const res = await app.request("/invalid-uuid", {
+        method: "GET",
+        headers: AuthTestHelper.createAuthHeaders(testToken),
+      })
+
+      expect(res.status).toBe(400)
+    })
+
+    test("未認証アクセスに対する401エラー", async () => {
+      const res = await app.request(`/${testActivityId}`, {
+        method: "GET",
+      })
+
+      expect(res.status).toBe(401)
+    })
+  })
+})

--- a/packages/backend/src/features/activities/presentation/routes/activities/index.ts
+++ b/packages/backend/src/features/activities/presentation/routes/activities/index.ts
@@ -1,0 +1,271 @@
+/**
+ * アクティビティルート定義
+ */
+
+import { OpenAPIHono, createRoute } from "@hono/zod-openapi"
+import { z } from "@hono/zod-openapi"
+import { requireAuth } from "../../../../identity/middleware/jwt-auth.middleware"
+import type {
+  ListUserActivitiesUseCase,
+  GetActivityDetailUseCase,
+} from "../../../application/use-cases"
+import {
+  ActivityListQuerySchema,
+  ActivityListResponseSchema,
+  ActivityDetailResponseSchema,
+} from "../../schemas"
+import { handleActivityError, ActivityError } from "../../shared/error-handling"
+import { toActivityId } from "../../../domain/activity"
+
+/**
+ * エラーレスポンススキーマ定義
+ */
+const activityErrorResponseSchemaDefinition = {
+  400: {
+    content: {
+      "application/json": {
+        schema: z.object({
+          success: z.literal(false),
+          error: z.object({
+            code: z.string(),
+            message: z.string(),
+            details: z.object({}).optional(),
+          }),
+        }),
+      },
+    },
+    description: "バリデーションエラー",
+  },
+  401: {
+    content: {
+      "application/json": {
+        schema: z.object({
+          success: z.literal(false),
+          error: z.object({
+            code: z.string(),
+            message: z.string(),
+          }),
+        }),
+      },
+    },
+    description: "認証エラー",
+  },
+  404: {
+    content: {
+      "application/json": {
+        schema: z.object({
+          success: z.literal(false),
+          error: z.object({
+            code: z.string(),
+            message: z.string(),
+            details: z.object({}).optional(),
+          }),
+        }),
+      },
+    },
+    description: "リソースが見つかりません",
+  },
+  500: {
+    content: {
+      "application/json": {
+        schema: z.object({
+          success: z.literal(false),
+          error: z.object({
+            code: z.string(),
+            message: z.string(),
+          }),
+        }),
+      },
+    },
+    description: "サーバーエラー",
+  },
+}
+
+/**
+ * アクティビティルート作成
+ */
+export function createActivityRoutes(
+  listUserActivitiesUseCase: ListUserActivitiesUseCase,
+  getActivityDetailUseCase: GetActivityDetailUseCase,
+) {
+  const app = new OpenAPIHono()
+
+  // ===== アクティビティ一覧取得機能 =====
+
+  /**
+   * GET /activities ルート定義
+   */
+  const listActivitiesRoute = createRoute({
+    method: "get",
+    path: "/",
+    summary: "ユーザーのアクティビティ一覧取得",
+    description:
+      "ユーザーが監視中のデータソースに関連するアクティビティ一覧を取得します。フィルタリング、ソート、ページネーションに対応しています",
+    tags: ["Activities"],
+    security: [{ Bearer: [] }],
+    request: {
+      query: ActivityListQuerySchema,
+    },
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            schema: ActivityListResponseSchema,
+          },
+        },
+        description: "アクティビティ一覧が正常に取得されました",
+      },
+      ...activityErrorResponseSchemaDefinition,
+    },
+  })
+
+  /**
+   * GET /activities - アクティビティ一覧取得エンドポイント
+   */
+  app.openapi(listActivitiesRoute, async (c) => {
+    try {
+      const authenticatedUser = requireAuth(c)
+      const userId = authenticatedUser.sub
+
+      const query = c.req.valid("query")
+
+      const result = await listUserActivitiesUseCase.execute({
+        userId,
+        filter: {
+          activityType: query.activityType,
+          status: query.status,
+          createdAfter: query.createdAfter
+            ? new Date(query.createdAfter)
+            : undefined,
+          createdBefore: query.createdBefore
+            ? new Date(query.createdBefore)
+            : undefined,
+          updatedAfter: query.updatedAfter
+            ? new Date(query.updatedAfter)
+            : undefined,
+          updatedBefore: query.updatedBefore
+            ? new Date(query.updatedBefore)
+            : undefined,
+        },
+        pagination: {
+          page: query.page,
+          perPage: query.perPage,
+        },
+        sort: {
+          sortBy: query.sortBy,
+          sortOrder: query.sortOrder,
+        },
+      })
+
+      return c.json(
+        {
+          success: true,
+          data: {
+            items: result.items.map((item) => ({
+              id: item.id,
+              dataSource: {
+                id: item.dataSource.id,
+                name: item.dataSource.name,
+                url: item.dataSource.url,
+              },
+              activityType: item.activityType,
+              title: item.title,
+              body: item.body,
+              version: item.version,
+              status: item.status,
+              createdAt: item.createdAt.toISOString(),
+              updatedAt: item.updatedAt.toISOString(),
+            })),
+            pagination: result.pagination,
+          },
+        },
+        200,
+      )
+    } catch (error) {
+      return handleActivityError(c, error, "list")
+    }
+  })
+
+  // ===== アクティビティ詳細取得機能 =====
+
+  /**
+   * GET /activities/:id ルート定義
+   */
+  const getActivityDetailRoute = createRoute({
+    method: "get",
+    path: "/:id",
+    summary: "アクティビティ詳細取得",
+    description:
+      "指定されたIDのアクティビティ詳細を取得します。ユーザーが監視中のデータソースに関連するアクティビティのみアクセス可能です",
+    tags: ["Activities"],
+    security: [{ Bearer: [] }],
+    request: {
+      params: z.object({
+        id: z.string().uuid().openapi({
+          description: "アクティビティID（UUID形式）",
+          example: "550e8400-e29b-41d4-a716-446655440000",
+        }),
+      }),
+    },
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            schema: ActivityDetailResponseSchema,
+          },
+        },
+        description: "アクティビティ詳細が正常に取得されました",
+      },
+      ...activityErrorResponseSchemaDefinition,
+    },
+  })
+
+  /**
+   * GET /activities/:id - アクティビティ詳細取得エンドポイント
+   */
+  app.openapi(getActivityDetailRoute, async (c) => {
+    try {
+      const authenticatedUser = requireAuth(c)
+      const auth0UserId = authenticatedUser.sub
+
+      const { id } = c.req.valid("param")
+
+      const result = await getActivityDetailUseCase.execute({
+        activityId: toActivityId(id),
+        userId: auth0UserId,
+      })
+
+      if (!result) {
+        throw ActivityError.activityNotFound(id)
+      }
+
+      return c.json(
+        {
+          success: true,
+          data: {
+            id: result.id,
+            dataSource: {
+              id: result.dataSource.id,
+              name: result.dataSource.name,
+              description: result.dataSource.description,
+              url: result.dataSource.url,
+            },
+            activityType: result.activityType,
+            title: result.title,
+            body: result.body,
+            version: result.version,
+            status: result.status,
+            statusDetail: result.statusDetail,
+            createdAt: result.createdAt.toISOString(),
+            updatedAt: result.updatedAt.toISOString(),
+          },
+        },
+        200,
+      )
+    } catch (error) {
+      return handleActivityError(c, error, "get detail")
+    }
+  })
+
+  return app
+}

--- a/packages/backend/src/features/activities/presentation/schemas/activity-detail-response.schema.ts
+++ b/packages/backend/src/features/activities/presentation/schemas/activity-detail-response.schema.ts
@@ -1,0 +1,90 @@
+/**
+ * アクティビティ詳細取得レスポンスのZodスキーマ
+ */
+
+import { z } from "@hono/zod-openapi"
+import {
+  ActivityTypeSchema,
+  ActivityStatusSchema,
+} from "./activity-list-request.schema"
+
+/**
+ * データソース詳細情報スキーマ
+ */
+const DataSourceDetailSchema = z.object({
+  id: z.string().uuid().openapi({
+    description: "データソースID",
+    example: "550e8400-e29b-41d4-a716-446655440000",
+  }),
+  name: z.string().openapi({
+    description: "データソース名",
+    example: "facebook/react",
+  }),
+  description: z.string().openapi({
+    description: "データソース説明",
+    example:
+      "A declarative, efficient, and flexible JavaScript library for building user interfaces.",
+  }),
+  url: z.string().url().openapi({
+    description: "データソースURL",
+    example: "https://github.com/facebook/react",
+  }),
+})
+
+/**
+ * アクティビティ詳細スキーマ
+ */
+const ActivityDetailDataSchema = z.object({
+  id: z.string().uuid().openapi({
+    description: "アクティビティID",
+    example: "550e8400-e29b-41d4-a716-446655440000",
+  }),
+  dataSource: DataSourceDetailSchema,
+  activityType: ActivityTypeSchema.openapi({
+    description: "アクティビティタイプ",
+    example: "release",
+  }),
+  title: z.string().openapi({
+    description: "タイトル",
+    example: "v18.3.0",
+  }),
+  body: z.string().openapi({
+    description: "本文",
+    example: "新機能の追加とバグ修正が含まれています。",
+  }),
+  version: z.string().nullable().openapi({
+    description: "バージョン（リリースの場合のみ）",
+    example: "18.3.0",
+  }),
+  status: ActivityStatusSchema.openapi({
+    description: "ステータス",
+    example: "completed",
+  }),
+  statusDetail: z.string().nullable().openapi({
+    description: "ステータス詳細",
+    example: null,
+  }),
+  createdAt: z.string().datetime().openapi({
+    description: "作成日時（ISO 8601形式）",
+    example: "2025-01-01T00:00:00Z",
+  }),
+  updatedAt: z.string().datetime().openapi({
+    description: "更新日時（ISO 8601形式）",
+    example: "2025-01-01T00:00:00Z",
+  }),
+})
+
+/**
+ * アクティビティ詳細レスポンススキーマ
+ */
+export const ActivityDetailResponseSchema = z.object({
+  success: z.literal(true).openapi({
+    description: "成功フラグ",
+    example: true,
+  }),
+  data: ActivityDetailDataSchema,
+})
+
+export type ActivityDetailResponse = z.infer<
+  typeof ActivityDetailResponseSchema
+>

--- a/packages/backend/src/features/activities/presentation/schemas/activity-list-request.schema.ts
+++ b/packages/backend/src/features/activities/presentation/schemas/activity-list-request.schema.ts
@@ -1,0 +1,90 @@
+/**
+ * アクティビティ一覧取得リクエストのZodスキーマ
+ */
+
+import { z } from "@hono/zod-openapi"
+
+/**
+ * アクティビティタイプ
+ */
+export const ActivityTypeSchema = z.enum(["release", "issue", "pull_request"])
+
+/**
+ * アクティビティステータス
+ */
+export const ActivityStatusSchema = z.enum([
+  "pending",
+  "processing",
+  "completed",
+  "failed",
+])
+
+/**
+ * ソート対象フィールド
+ */
+export const SortBySchema = z.enum(["createdAt", "updatedAt"])
+
+/**
+ * ソート順
+ */
+export const SortOrderSchema = z.enum(["asc", "desc"])
+
+/**
+ * クエリパラメータスキーマ
+ */
+export const ActivityListQuerySchema = z.object({
+  activityType: ActivityTypeSchema.optional().openapi({
+    description: "アクティビティタイプでのフィルタリング",
+    example: "release",
+  }),
+  status: ActivityStatusSchema.optional().openapi({
+    description: "ステータスでのフィルタリング",
+    example: "completed",
+  }),
+  createdAfter: z.string().datetime().optional().openapi({
+    description: "この日時以降に作成されたアクティビティを取得（ISO 8601形式）",
+    example: "2025-01-01T00:00:00Z",
+  }),
+  createdBefore: z.string().datetime().optional().openapi({
+    description: "この日時以前に作成されたアクティビティを取得（ISO 8601形式）",
+    example: "2025-12-31T23:59:59Z",
+  }),
+  updatedAfter: z.string().datetime().optional().openapi({
+    description: "この日時以降に更新されたアクティビティを取得（ISO 8601形式）",
+    example: "2025-01-01T00:00:00Z",
+  }),
+  updatedBefore: z.string().datetime().optional().openapi({
+    description: "この日時以前に更新されたアクティビティを取得（ISO 8601形式）",
+    example: "2025-12-31T23:59:59Z",
+  }),
+  page: z
+    .string()
+    .regex(/^\d+$/)
+    .transform(Number)
+    .pipe(z.number().int().min(1))
+    .optional()
+    .openapi({
+      description: "ページ番号（デフォルト: 1）",
+      example: "1",
+    }),
+  perPage: z
+    .string()
+    .regex(/^\d+$/)
+    .transform(Number)
+    .pipe(z.number().int().min(1).max(100))
+    .optional()
+    .openapi({
+      description: "1ページあたりの件数（デフォルト: 20、最大: 100）",
+      example: "20",
+    }),
+  sortBy: SortBySchema.optional().default("createdAt").openapi({
+    description: "ソート対象フィールド（デフォルト: createdAt）",
+    example: "createdAt",
+  }),
+  sortOrder: SortOrderSchema.optional().default("desc").openapi({
+    description: "ソート順（デフォルト: desc）",
+    example: "desc",
+  }),
+})
+
+export type ActivityListQuery = z.infer<typeof ActivityListQuerySchema>

--- a/packages/backend/src/features/activities/presentation/schemas/activity-list-response.schema.ts
+++ b/packages/backend/src/features/activities/presentation/schemas/activity-list-response.schema.ts
@@ -1,0 +1,108 @@
+/**
+ * アクティビティ一覧取得レスポンスのZodスキーマ
+ */
+
+import { z } from "@hono/zod-openapi"
+import {
+  ActivityTypeSchema,
+  ActivityStatusSchema,
+} from "./activity-list-request.schema"
+
+/**
+ * データソース情報スキーマ（一覧用）
+ */
+const DataSourceInfoSchema = z.object({
+  id: z.string().uuid().openapi({
+    description: "データソースID",
+    example: "550e8400-e29b-41d4-a716-446655440000",
+  }),
+  name: z.string().openapi({
+    description: "データソース名",
+    example: "facebook/react",
+  }),
+  url: z.string().url().openapi({
+    description: "データソースURL",
+    example: "https://github.com/facebook/react",
+  }),
+})
+
+/**
+ * アクティビティ項目スキーマ
+ */
+const ActivityItemSchema = z.object({
+  id: z.string().uuid().openapi({
+    description: "アクティビティID",
+    example: "550e8400-e29b-41d4-a716-446655440000",
+  }),
+  dataSource: DataSourceInfoSchema,
+  activityType: ActivityTypeSchema.openapi({
+    description: "アクティビティタイプ",
+    example: "release",
+  }),
+  title: z.string().openapi({
+    description: "タイトル",
+    example: "v18.3.0",
+  }),
+  body: z.string().openapi({
+    description: "本文",
+    example: "新機能の追加とバグ修正が含まれています。",
+  }),
+  version: z.string().nullable().openapi({
+    description: "バージョン（リリースの場合のみ）",
+    example: "18.3.0",
+  }),
+  status: ActivityStatusSchema.openapi({
+    description: "ステータス",
+    example: "completed",
+  }),
+  createdAt: z.string().datetime().openapi({
+    description: "作成日時（ISO 8601形式）",
+    example: "2025-01-01T00:00:00Z",
+  }),
+  updatedAt: z.string().datetime().openapi({
+    description: "更新日時（ISO 8601形式）",
+    example: "2025-01-01T00:00:00Z",
+  }),
+})
+
+/**
+ * ページネーション情報スキーマ
+ */
+const PaginationInfoSchema = z.object({
+  currentPage: z.number().int().min(1).openapi({
+    description: "現在のページ番号",
+    example: 1,
+  }),
+  perPage: z.number().int().min(1).max(100).openapi({
+    description: "1ページあたりの件数",
+    example: 20,
+  }),
+  totalItems: z.number().int().min(0).openapi({
+    description: "総件数",
+    example: 100,
+  }),
+  totalPages: z.number().int().min(0).openapi({
+    description: "総ページ数",
+    example: 5,
+  }),
+})
+
+/**
+ * アクティビティ一覧レスポンススキーマ
+ */
+export const ActivityListResponseSchema = z.object({
+  success: z.literal(true).openapi({
+    description: "成功フラグ",
+    example: true,
+  }),
+  data: z.object({
+    items: z.array(ActivityItemSchema).openapi({
+      description: "アクティビティ一覧",
+    }),
+    pagination: PaginationInfoSchema.openapi({
+      description: "ページネーション情報",
+    }),
+  }),
+})
+
+export type ActivityListResponse = z.infer<typeof ActivityListResponseSchema>

--- a/packages/backend/src/features/activities/presentation/schemas/index.ts
+++ b/packages/backend/src/features/activities/presentation/schemas/index.ts
@@ -1,0 +1,7 @@
+/**
+ * アクティビティスキーマのバレルファイル
+ */
+
+export * from "./activity-list-request.schema"
+export * from "./activity-list-response.schema"
+export * from "./activity-detail-response.schema"

--- a/packages/backend/src/features/activities/presentation/shared/error-handling.ts
+++ b/packages/backend/src/features/activities/presentation/shared/error-handling.ts
@@ -1,0 +1,133 @@
+/**
+ * アクティビティエラーハンドリング
+ */
+
+import type { Context } from "hono"
+
+/**
+ * アクティビティエラーコード定義
+ */
+export const ACTIVITY_ERROR_CODES = {
+  ACTIVITY_NOT_FOUND: "ACTIVITY_NOT_FOUND",
+  DATA_SOURCE_NOT_FOUND: "DATA_SOURCE_NOT_FOUND",
+  INVALID_PARAMETER: "INVALID_PARAMETER",
+  UNAUTHORIZED: "UNAUTHORIZED",
+  INTERNAL_ERROR: "INTERNAL_ERROR",
+} as const
+
+export type ActivityErrorCode =
+  (typeof ACTIVITY_ERROR_CODES)[keyof typeof ACTIVITY_ERROR_CODES]
+
+/**
+ * エラー詳細情報の型定義
+ */
+export type ErrorDetails = {
+  field?: string
+  value?: string
+}
+
+/**
+ * アクティビティカスタムエラークラス
+ */
+export class ActivityError extends Error {
+  public readonly code: ActivityErrorCode
+  public readonly httpStatus: number
+  public readonly details?: ErrorDetails
+
+  constructor(params: {
+    code: ActivityErrorCode
+    message: string
+    httpStatus: number
+    details?: ErrorDetails
+  }) {
+    super(params.message)
+    this.name = "ActivityError"
+    this.code = params.code
+    this.httpStatus = params.httpStatus
+    this.details = params.details
+  }
+
+  static activityNotFound(activityId?: string): ActivityError {
+    return new ActivityError({
+      code: ACTIVITY_ERROR_CODES.ACTIVITY_NOT_FOUND,
+      message: "アクティビティが見つかりません、またはアクセス権限がありません",
+      httpStatus: 404,
+      details: activityId ? { field: "id", value: activityId } : undefined,
+    })
+  }
+
+  static dataSourceNotFound(dataSourceId?: string): ActivityError {
+    return new ActivityError({
+      code: ACTIVITY_ERROR_CODES.DATA_SOURCE_NOT_FOUND,
+      message: "データソースが見つかりません、またはアクセス権限がありません",
+      httpStatus: 404,
+      details: dataSourceId
+        ? { field: "dataSourceId", value: dataSourceId }
+        : undefined,
+    })
+  }
+
+  static invalidParameter(field: string, message?: string): ActivityError {
+    return new ActivityError({
+      code: ACTIVITY_ERROR_CODES.INVALID_PARAMETER,
+      message: message || `無効なパラメータです: ${field}`,
+      httpStatus: 400,
+      details: { field },
+    })
+  }
+
+  static unauthorized(message?: string): ActivityError {
+    return new ActivityError({
+      code: ACTIVITY_ERROR_CODES.UNAUTHORIZED,
+      message: message || "認証が必要です",
+      httpStatus: 401,
+    })
+  }
+
+  static internalError(message?: string): ActivityError {
+    return new ActivityError({
+      code: ACTIVITY_ERROR_CODES.INTERNAL_ERROR,
+      message: message || "内部サーバーエラーが発生しました",
+      httpStatus: 500,
+    })
+  }
+}
+
+/**
+ * アクティビティ操作のエラーハンドリング
+ */
+export function handleActivityError(
+  c: Context,
+  error: unknown,
+  operation: string,
+) {
+  console.error(`Activity ${operation} error:`, error)
+
+  // 既知のカスタムエラー
+  if (error instanceof ActivityError) {
+    return c.json(
+      {
+        success: false,
+        error: {
+          code: error.code,
+          message: error.message,
+          details: error.details,
+        },
+      },
+      error.httpStatus as 400 | 401 | 404 | 500,
+    )
+  }
+
+  // その他のエラー
+  const activityError = ActivityError.internalError()
+  return c.json(
+    {
+      success: false,
+      error: {
+        code: activityError.code,
+        message: activityError.message,
+      },
+    },
+    activityError.httpStatus as 500,
+  )
+}

--- a/packages/backend/src/features/data-sources/index.ts
+++ b/packages/backend/src/features/data-sources/index.ts
@@ -11,6 +11,7 @@ import {
   UpdateDataSourceUseCase,
   RemoveDataSourceWatchUseCase,
 } from "./application/use-cases"
+import { listDataSourceActivitiesUseCase } from "../activities"
 import { createDataSourcePresentationRoutes } from "./presentation"
 
 const dataSourceRepository = new DrizzleDataSourceRepository()
@@ -52,6 +53,7 @@ const dataSourceRoutes = createDataSourcePresentationRoutes(
   getDataSourceUseCase,
   updateDataSourceUseCase,
   removeDataSourceWatchUseCase,
+  listDataSourceActivitiesUseCase,
 )
 
 export default dataSourceRoutes

--- a/packages/backend/src/features/data-sources/presentation/routes.ts
+++ b/packages/backend/src/features/data-sources/presentation/routes.ts
@@ -6,6 +6,7 @@ import type {
   UpdateDataSourceUseCase,
   RemoveDataSourceWatchUseCase,
 } from "../application/use-cases"
+import type { ListDataSourceActivitiesUseCase } from "../../activities/application/use-cases"
 import { createDataSourceRoutes } from "./routes/data-sources"
 
 /**
@@ -17,6 +18,7 @@ export function createDataSourcePresentationRoutes(
   getDataSourceUseCase: GetDataSourceUseCase,
   updateDataSourceUseCase: UpdateDataSourceUseCase,
   removeDataSourceWatchUseCase: RemoveDataSourceWatchUseCase,
+  listDataSourceActivitiesUseCase: ListDataSourceActivitiesUseCase,
 ) {
   const app = new OpenAPIHono()
 
@@ -29,6 +31,7 @@ export function createDataSourcePresentationRoutes(
       getDataSourceUseCase,
       updateDataSourceUseCase,
       removeDataSourceWatchUseCase,
+      listDataSourceActivitiesUseCase,
     ),
   )
 

--- a/packages/backend/src/shared/types/brand.ts
+++ b/packages/backend/src/shared/types/brand.ts
@@ -1,0 +1,16 @@
+/**
+ * Brand型のヘルパー型定義
+ *
+ * TypeScriptでのNominal Typingを実現するためのヘルパー型
+ */
+
+/**
+ * Brand型
+ *
+ * 基底型にブランドタグを付与して、型安全性を向上させる
+ *
+ * @example
+ * type UserId = Brand<string, "UserId">
+ * type ActivityId = Brand<string, "ActivityId">
+ */
+export type Brand<T, BrandTag> = T & { readonly __brand: BrandTag }


### PR DESCRIPTION
## 概要

CHASE-120: アクティビティ一覧・詳細取得APIの実装

ユーザーが監視中のデータソースに関連するアクティビティ（リリース、PR、Issue等）を取得するAPIを実装しました。

## 実装内容

### 📋 新規エンドポイント

1. **GET /activities** - アクティビティ一覧取得
   - ユーザーが監視中のデータソースのアクティビティ一覧を取得
   - フィルタリング（activityType, status, 日付範囲）
   - ソート（createdAt/updatedAt, asc/desc）
   - ページネーション対応

2. **GET /activities/:id** - アクティビティ詳細取得
   - 特定のアクティビティの詳細情報を取得
   - データソース情報も含む
   - アクセス権限チェック（監視中のデータソースのみ）

3. **GET /data-sources/:id/activities** - データソース別アクティビティ一覧
   - 特定のデータソースに関連するアクティビティ一覧を取得
   - フィルタリング、ソート、ページネーション対応

### 🏗️ アーキテクチャ

#### Domain層
- `Activity`型定義とBrand型による型安全性の確保
- `ActivityRepository`インターフェース定義
- フィルタリング、ソート、ページネーション用の型定義

#### Application層  
- `ListUserActivitiesUseCase`: ユーザーのアクティビティ一覧取得
- `GetActivityDetailUseCase`: アクティビティ詳細取得
- `ListDataSourceActivitiesUseCase`: データソース別アクティビティ一覧取得

#### Infrastructure層
- `DrizzleActivityRepository`: ActivityRepositoryの実装
- Auth0ユーザーIDとinternal UUIDのマッピング対応
- `user_watches`テーブルを通じたアクセス制御

#### Presentation層
- OpenAPIスキーマ定義（Zod）
- エラーハンドリングとバリデーション
- スキーマコロケーション

### 🧪 テスト

- **activities routes**: 15テストケース
  - 一覧取得の正常系・異常系
  - ページネーション、フィルタリング、ソート機能
  - アクセス権限チェック
  
- **data-sources/:id/activities**: 6テストケース
  - データソース別アクティビティ取得
  - ページネーション、フィルタリング
  - 未監視データソースへのアクセス制御

全166テスト成功 (3 skipped)

## 技術的な工夫

### 1. Brand型による型安全なID管理
```typescript
export type ActivityId = Brand<string, "ActivityId">
```
- コンパイル時の型安全性を確保
- 異なる種類のIDの混在を防止

### 2. Repository層でのAuth0 IDマッピング
- Repository層で`users`テーブルをJOIN
- Auth0ユーザーID（`auth0|xxx`）からinternal UUIDへのマッピング
- Route層はAuth0 IDのみを意識すればよい設計

### 3. アクセス制御の実装
- `user_watches`テーブルを通じた権限チェック
- SQLレベルでアクセス制御を実現
- N+1問題の回避

### 4. スキーマコロケーション
- スキーマ定義をプレゼンテーション層に配置
- ルート定義とスキーマの保守性向上

## 関連ドキュメント

- SOW: `docs/sow/20251005-CHASE-120.md`
- 作業ログ: `docs/task-logs/CHASE-120/20251005-01-log.md`

## チェックリスト

- [x] フォルダ構成ガイドラインに準拠
- [x] アーキテクチャパターンに準拠（Zod + Parser）
- [x] APIルート実装ガイドに準拠
- [x] ファイル命名規則に準拠
- [x] テスト戦略に準拠（Component Test実装）
- [x] 型安全性の確保（Brand型活用）
- [x] Lint/Format/Test すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)