### PR TITLE
feat(CHASE-140): Activity保存内容の修正（翻訳・要約の保持）

### DIFF
--- a/docs/sow/20251026-CHASE-140.md
+++ b/docs/sow/20251026-CHASE-140.md
@@ -1,0 +1,393 @@
+# SOW: CHASE-140: Activity保存内容の修正（detection機能／翻訳・要約の保持）
+
+## プロジェクト概要
+
+**課題ID**: CHASE-140
+**作成日**: 2025-10-26
+**種別**: 機能改善
+
+## 1. 背景と目的
+
+### 背景
+
+現在のdetection機能では、GitHubから取得したActivityデータ（リリース、Issue、PR）を翻訳してDBに保存していますが、以下の課題があります：
+
+- 原文が翻訳結果で上書きされ、原文が失われる
+- 本文の要約が生成・保存されていない
+- 翻訳済み本文と要約が明確に区別されていない
+
+### 目的
+
+Activityテーブルのスキーマを見直し、原文と翻訳/要約を併存できるようにします。これにより、以下を実現します：
+
+- 原文（タイトル/本文）を保持しながら、翻訳済みタイトル、本文要約、翻訳済み本文を別フィールドで管理
+- OpenAI APIを使った翻訳・要約の自動生成
+- OpenAI APIキー未設定時のフォールバック動作の実装
+
+## 2. 実装スコープ
+
+### 実装対象
+
+- Activityテーブルのスキーマ拡張（翻訳・要約フィールド追加）
+- 要約生成機能の実装（新しいポート・アダプタ）
+- 既存の翻訳・保存ロジックの修正（原文を保持するように変更）
+- OpenAI APIキー未設定時のフォールバック処理
+
+### 実装除外項目
+
+- 翻訳済み本文の生成機能（今回はNULLとして保存し、別タスクで実装予定）
+- 既存Activityデータのマイグレーション処理（新規フィールドはNULLを許可）
+- フロントエンドでの表示対応
+
+## 3. 技術仕様
+
+### データベース操作
+
+#### スキーマ変更
+
+`activities`テーブルに以下のカラムを追加：
+
+```sql
+-- 翻訳済みタイトル（日本語）
+translatedTitle TEXT NULL
+
+-- 本文要約（日本語、AIによる要約）
+summary TEXT NULL
+
+-- 翻訳済み本文（日本語、フル翻訳）※今回はNULL
+translatedBody TEXT NULL
+```
+
+既存カラム：
+- `title`: 原文タイトル（英語）
+- `body`: 原文本文（英語）
+
+#### マイグレーション方針
+
+- 新規カラムは全てNULL許可
+- 既存データには影響なし（新規カラムはNULL）
+- Drizzle Kitによる自動マイグレーション生成
+
+### アーキテクチャ設計
+
+既存のdetection機能と同じレイヤード構成を採用：
+
+#### Domain層
+
+- **`Activity`型の拡張**: `translatedTitle`, `summary`, `translatedBody`フィールドを追加
+
+#### Application層（Ports）
+
+- **新規ポート: `SummarizationPort`**
+  - `summarize(activityType, title, body): Promise<{ summary: string }>`
+  - アクティビティタイプに応じた本文要約を生成
+
+- **既存ポート: `TranslationPort`**（変更なし）
+  - `translate(activityType, title, body): Promise<{ translatedTitle, translatedBody }>`
+
+#### Infra層（Adapters）
+
+- **新規アダプタ: `SummarizationAdapter`**
+  - OpenAI APIを使った要約生成
+  - プロンプト: アクティビティタイプ別の要約指示
+  - レスポンスフォーマット: JSON Schema
+  - エラーハンドリング: TranslationAdapterと同様の実装
+
+- **新規スタブ: `SummarizationStubAdapter`**
+  - テスト用スタブ実装
+  - ダミーの要約を返す
+
+#### Infra層（Repositories）
+
+- **`ActivityRepository`の更新**
+  - `upsert()`: 翻訳・要約フィールドを含むパラメータを追加（オプション）
+  - `upsertMany()`: 同上
+  - `updateWithTranslation()`: **廃止** (原文を上書きするため)
+  - `updateTranslationAndSummary()`: **新規追加** - 翻訳・要約のみを更新
+
+- **`DrizzleActivityRepository`の更新**
+  - `updateTranslationAndSummary(activityId, translatedTitle, summary, status, statusDetail)`を実装
+  - `mapToDomain()`で新フィールドをマッピング
+
+#### Application層（Use Cases）
+
+- **`ProcessUpdatesUseCase`の更新**
+  - 翻訳に加えて要約も生成
+  - 原文を保持したまま、翻訳・要約フィールドのみを更新
+  - OpenAI APIキー未設定時は翻訳・要約をNULLのまま処理継続（ステータスはCOMPLETED）
+
+### OpenAI APIキー未設定時のフォールバック処理
+
+```typescript
+// getOpenAiConfig()をtry-catchで囲み、失敗時はnullを返す
+let openAiConfig: OpenAiConfig | null = null
+try {
+  openAiConfig = await getOpenAiConfig()
+} catch (error) {
+  console.warn("OpenAI API key not configured. Translation and summarization will be skipped.")
+}
+
+// openAiConfigがnullの場合、翻訳・要約をスキップして処理継続
+if (openAiConfig) {
+  // 翻訳・要約を実行
+} else {
+  // ステータスをCOMPLETEDとして保存（翻訳・要約はNULL）
+}
+```
+
+### データフロー
+
+```
+1. DetectUpdateUseCase
+   ↓ GitHub APIからデータ取得
+   ↓ Activityとして保存（原文のまま、status=PENDING）
+   ↓ 新規ActivityのIDリストを返す
+
+2. ProcessUpdatesUseCase
+   ↓ ActivityIDリストを受け取る
+   ↓ OpenAI設定を取得（失敗時はnull）
+   ↓
+   ├─ OpenAI設定あり
+   │  ↓ 翻訳・要約を生成（TranslationPort, SummarizationPort）
+   │  ↓ translatedTitle, summaryを更新（原文は保持）
+   │  ↓ status=COMPLETEDで保存
+   │
+   └─ OpenAI設定なし
+      ↓ 翻訳・要約をスキップ
+      ↓ status=COMPLETEDで保存（translatedTitle, summaryはNULL）
+```
+
+## 4. 実装ファイル一覧
+
+### 新規作成ファイル
+
+1. **`packages/backend/src/features/detection/application/ports/summarization.port.ts`**
+   - 要約生成のポート定義
+   - `SummarizationPort`インターフェース
+   - アクティビティタイプ別の要約プロンプト定数
+
+2. **`packages/backend/src/features/detection/infra/adapters/summarization/summarization.adapter.ts`**
+   - OpenAI APIを使った要約生成アダプタ
+   - エラーハンドリング、レート制限対応
+
+3. **`packages/backend/src/features/detection/infra/adapters/summarization/summarization-stub.adapter.ts`**
+   - テスト用スタブ実装
+
+4. **`packages/backend/drizzle/migrations/XXXXXX_add_translation_summary_fields.sql`**
+   - スキーママイグレーションSQL（Drizzle Kitにより自動生成）
+
+### 更新対象ファイル
+
+1. **`packages/backend/src/db/schema.ts`**
+   - `activities`テーブル定義に`translatedTitle`, `summary`, `translatedBody`カラムを追加
+
+2. **`packages/backend/src/features/activities/domain/activity.ts`**
+   - `Activity`型、`ActivityRecord`型に新フィールドを追加
+
+3. **`packages/backend/src/features/detection/domain/repositories/activity.repository.ts`**
+   - `upsert()`, `upsertMany()`のパラメータに翻訳・要約フィールドを追加（オプション）
+   - `updateWithTranslation()`を削除
+   - `updateTranslationAndSummary()`を追加
+
+4. **`packages/backend/src/features/detection/infra/repositories/drizzle-activity.repository.ts`**
+   - `updateWithTranslation()`を削除
+   - `updateTranslationAndSummary()`を実装
+   - `mapToDomain()`で新フィールドをマッピング
+
+5. **`packages/backend/src/features/detection/application/use-cases/process-updates.use-case.ts`**
+   - `processActivity()`メソッドを更新
+     - 翻訳・要約を生成
+     - `updateTranslationAndSummary()`を呼び出し
+     - OpenAI設定未取得時のフォールバック処理
+
+6. **`packages/backend/src/features/detection/workers/process-updates/handler.ts`**
+   - `SummarizationAdapter`のインスタンス化
+   - `ProcessUpdatesUseCase`への依存注入
+   - OpenAI設定取得のエラーハンドリング
+
+7. **`packages/backend/src/core/config/open-ai.ts`**
+   - `getOpenAiConfig()`が例外をスローしないように修正（または呼び出し側でハンドリング）
+
+### テスト更新対象ファイル
+
+1. **`packages/backend/src/features/detection/workers/process-updates/__tests__/handler.test.ts`**
+   - 翻訳・要約フィールドの検証を追加
+   - OpenAI設定未取得時のフォールバックテストを追加
+
+## 5. テスト戦略
+
+### Component Test（Worker層）
+
+**`process-updates/__tests__/handler.test.ts`**:
+
+- OpenAI設定取得成功時の翻訳・要約生成テスト
+  - Activityに`translatedTitle`, `summary`が保存されること
+  - `translatedBody`はNULLであること
+  - ステータスが`COMPLETED`であること
+  - 原文（`title`, `body`）が保持されていること
+
+- OpenAI設定取得失敗時のフォールバックテスト
+  - 翻訳・要約がNULLのまま処理が継続されること
+  - ステータスが`COMPLETED`であること
+  - エラーが発生しないこと
+
+- 翻訳・要約生成失敗時のエラーハンドリングテスト
+  - ステータスが`FAILED`になること
+  - `statusDetail`にエラー内容が記録されること
+
+### Unit Test（Adapter層）
+
+**`summarization.adapter.test.ts`** (新規):
+
+- 正常系: OpenAI APIが正しく要約を返すこと
+- 異常系: APIエラー時に適切な例外がスローされること
+- 異常系: レート制限時のエラーハンドリング
+
+### Unit Test（Repository層）
+
+**`drizzle-activity.repository.test.ts`** (更新):
+
+- `updateTranslationAndSummary()`の正常系テスト
+- 新フィールドのマッピングテスト
+
+## 6. 受け入れ基準
+
+### 機能要件
+
+- [ ] Activityに原文（`title`, `body`）と翻訳済みタイトル（`translatedTitle`）、本文要約（`summary`）が同時に保存されること
+- [ ] 翻訳済み本文（`translatedBody`）はNULLであること
+- [ ] OpenAI APIキー未設定時は翻訳・要約をNULLのまま処理が継続され、ステータスが`COMPLETED`になること
+- [ ] 原文が翻訳結果で上書きされないこと
+- [ ] 要約がアクティビティタイプに応じた適切な内容であること
+
+### 非機能要件
+
+- [ ] 既存のテストが全て通ること
+- [ ] 新規フィールド追加による既存データへの影響がないこと（NULL許可のため）
+- [ ] マイグレーションが正常に実行できること
+
+### セキュリティ要件
+
+- [ ] OpenAI APIキーが適切に管理されていること（SSM Parameter Store経由）
+- [ ] プロンプトインジェクション対策が実装されていること（既存のTranslationAdapterと同様）
+
+## 7. 実装手順
+
+### Phase 1: スキーマ・ドメイン層実装
+
+- 1-1. `schema.ts`に新フィールド追加
+- 1-2. Drizzle Kitでマイグレーションファイル生成
+- 1-3. `Activity`型に新フィールド追加
+- 1-4. ローカルDBでマイグレーション実行・確認
+
+### Phase 2: 要約機能の実装（Port/Adapter）
+
+- 2-1. `SummarizationPort`の定義
+- 2-2. `SummarizationAdapter`の実装
+- 2-3. `SummarizationStubAdapter`の実装
+- 2-4. Adapterのユニットテスト作成・実行
+
+### Phase 3: Repository層の更新
+
+- 3-1. `ActivityRepository`インターフェースの更新
+  - `updateTranslationAndSummary()`の追加
+  - `updateWithTranslation()`の削除（または非推奨化）
+- 3-2. `DrizzleActivityRepository`の実装更新
+- 3-3. `mapToDomain()`の更新
+- 3-4. Repositoryのユニットテスト更新・実行
+
+### Phase 4: UseCase層の更新
+
+- 4-1. `ProcessUpdatesUseCase`の更新
+  - コンストラクタに`SummarizationPort`を追加
+  - `processActivity()`メソッドの更新（翻訳・要約を両方実行）
+  - `updateTranslationAndSummary()`呼び出しに変更
+- 4-2. OpenAI設定未取得時のフォールバック処理実装
+
+### Phase 5: Worker層の更新
+
+- 5-1. `process-updates/handler.ts`の更新
+  - OpenAI設定取得のエラーハンドリング
+  - `SummarizationAdapter`のインスタンス化
+  - `ProcessUpdatesUseCase`への依存注入
+- 5-2. Componentテストの更新・実行
+
+### Phase 6: 統合テスト・動作確認
+
+- 6-1. ローカル環境での動作確認
+  - OpenAI APIキー設定あり/なしの両方で確認
+- 6-2. 全テストの実行・確認
+- 6-3. コードレビュー準備（フォーマット、リント）
+
+## 8. ディレクトリツリー
+
+### 新規作成ファイル
+
+```
+packages/backend/src/features/detection/
+├── application/
+│   └── ports/
+│       └── summarization.port.ts (新規)
+└── infra/
+    └── adapters/
+        └── summarization/
+            ├── summarization.adapter.ts (新規)
+            └── summarization-stub.adapter.ts (新規)
+```
+
+### 更新ファイル
+
+```
+packages/backend/
+├── src/
+│   ├── db/
+│   │   └── schema.ts (更新)
+│   ├── features/
+│   │   ├── activities/
+│   │   │   └── domain/
+│   │   │       └── activity.ts (更新)
+│   │   └── detection/
+│   │       ├── domain/
+│   │       │   └── repositories/
+│   │       │       └── activity.repository.ts (更新)
+│   │       ├── application/
+│   │       │   └── use-cases/
+│   │       │       └── process-updates.use-case.ts (更新)
+│   │       ├── infra/
+│   │       │   └── repositories/
+│   │       │       └── drizzle-activity.repository.ts (更新)
+│   │       └── workers/
+│   │           └── process-updates/
+│   │               ├── handler.ts (更新)
+│   │               └── __tests__/
+│   │                   └── handler.test.ts (更新)
+│   └── core/
+│       └── config/
+│           └── open-ai.ts (必要に応じて更新)
+└── drizzle/
+    └── migrations/
+        └── XXXXXX_add_translation_summary_fields.sql (自動生成)
+```
+
+## 9. リスク・考慮事項
+
+### 技術的リスク
+
+- **OpenAI APIの可用性**: APIがダウンした場合の処理継続性
+- **トークン制限**: 本文が長い場合のトークン超過エラー
+- **既存データへの影響**: マイグレーション時の既存データの整合性
+- **パフォーマンス**: 翻訳・要約の両方を実行することによる処理時間の増加
+
+### 軽減策
+
+- OpenAI APIキー未設定時のフォールバック処理により、処理継続性を確保
+- TranslationAdapterと同様のエラーハンドリングとリトライ機構
+- マイグレーションは新規フィールドをNULL許可とすることで、既存データへの影響を最小化
+- 翻訳・要約は並列実行可能な場合は並列化を検討（将来の最適化）
+- ステータス管理により、失敗したActivityのみを再処理可能
+
+### 将来の拡張性
+
+- 翻訳済み本文（`translatedBody`）の生成は別タスクで実装予定
+- ユーザーからの明示的なリクエストによる翻訳済み本文生成ワーカー
+- 要約のカスタマイズ（長さ、詳細度など）

--- a/docs/task-logs/CHASE-140/20251026-01-log.md
+++ b/docs/task-logs/CHASE-140/20251026-01-log.md
@@ -1,0 +1,221 @@
+# 作業ログ: CHASE-140 Activity保存内容の修正
+
+**作業日**: 2025-10-26
+**課題ID**: CHASE-140
+**SOW**: docs/sow/20251026-CHASE-140.md
+
+## 概要
+
+Activityテーブルのスキーマを拡張し、原文と翻訳/要約を併存できるようにする。
+- 原文（タイトル/本文）を保持
+- 翻訳済みタイトル、本文要約、翻訳済み本文を別フィールドで管理
+- OpenAI APIを使った要約生成機能の追加
+- OpenAI APIキー未設定時のフォールバック処理
+
+## 実装計画
+
+### Phase 1: スキーマ・ドメイン層実装
+
+- [ ] 1-1. `schema.ts`に新フィールド追加
+  - ファイル: `packages/backend/src/db/schema.ts`
+  - 追加フィールド: `translatedTitle`, `summary`, `translatedBody`（全てTEXT NULL）
+
+- [ ] 1-2. Drizzle Kitでマイグレーションファイル生成
+  - コマンド: `pnpm --filter backend db:generate`
+
+- [ ] 1-3. `Activity`型に新フィールド追加
+  - ファイル: `packages/backend/src/features/activities/domain/activity.ts`
+  - 追加フィールド: `translatedTitle`, `summary`, `translatedBody`（全てオプショナル）
+
+- [ ] 1-4. ローカルDBでマイグレーション実行・確認
+  - コマンド: `pnpm --filter backend db:push`
+
+### Phase 2: 要約機能の実装（Port/Adapter）
+
+- [ ] 2-1. `SummarizationPort`の定義
+  - ファイル: `packages/backend/src/features/detection/application/ports/summarization.port.ts`
+  - 内容: `summarize(activityType, title, body): Promise<{ summary: string }>`
+
+- [ ] 2-2. `SummarizationAdapter`の実装
+  - ファイル: `packages/backend/src/features/detection/infra/adapters/summarization/summarization.adapter.ts`
+  - OpenAI APIを使った要約生成
+  - TranslationAdapterと同様のエラーハンドリング
+
+- [ ] 2-3. `SummarizationStubAdapter`の実装
+  - ファイル: `packages/backend/src/features/detection/infra/adapters/summarization/summarization-stub.adapter.ts`
+  - テスト用スタブ実装
+
+### Phase 3: Repository層の更新
+
+- [ ] 3-1. `ActivityRepository`インターフェースの更新
+  - ファイル: `packages/backend/src/features/detection/domain/repositories/activity.repository.ts`
+  - `updateTranslationAndSummary()`の追加
+  - `upsert()`、`upsertMany()`のパラメータに翻訳・要約フィールドを追加（オプション）
+
+- [ ] 3-2. `DrizzleActivityRepository`の実装更新
+  - ファイル: `packages/backend/src/features/detection/infra/repositories/drizzle-activity.repository.ts`
+  - `updateTranslationAndSummary()`の実装
+  - `mapToDomain()`の更新（新フィールドのマッピング）
+
+### Phase 4: UseCase層の更新
+
+- [ ] 4-1. `ProcessUpdatesUseCase`の更新
+  - ファイル: `packages/backend/src/features/detection/application/use-cases/process-updates.use-case.ts`
+  - コンストラクタに`SummarizationPort`を追加
+  - `processActivity()`メソッドの更新（翻訳・要約を両方実行）
+  - `updateTranslationAndSummary()`呼び出しに変更
+  - OpenAI設定未取得時のフォールバック処理実装
+
+### Phase 5: Worker層の更新
+
+- [ ] 5-1. `process-updates/handler.ts`の更新
+  - ファイル: `packages/backend/src/features/detection/workers/process-updates/handler.ts`
+  - OpenAI設定取得のエラーハンドリング
+  - `SummarizationAdapter`のインスタンス化
+  - `ProcessUpdatesUseCase`への依存注入
+
+### Phase 6: テストの更新・実行
+
+- [ ] 6-1. Componentテストの更新
+  - ファイル: `packages/backend/src/features/detection/workers/process-updates/__tests__/handler.test.ts`
+  - 翻訳・要約フィールドの検証を追加
+  - OpenAI設定未取得時のフォールバックテストを追加
+
+- [ ] 6-2. 全テストの実行・確認
+  - コマンド: `pnpm --filter backend test`
+
+- [ ] 6-3. Lint/Format
+  - コマンド: `pnpm --filter backend lint`
+  - コマンド: `pnpm --filter backend format`
+
+## 実装の詳細
+
+### Phase 1: スキーマ・ドメイン層実装
+
+#### 1-1. schema.ts の変更内容
+
+```typescript
+// activities テーブルに以下を追加:
+translatedTitle: text("translated_title"),
+summary: text("summary"),
+translatedBody: text("translated_body"),
+```
+
+#### 1-3. Activity型の変更内容
+
+```typescript
+// Activity型に以下を追加（全てオプショナル）:
+translatedTitle?: string
+summary?: string
+translatedBody?: string
+```
+
+### Phase 2: 要約機能の実装
+
+#### SummarizationPort の仕様
+
+- メソッド: `summarize(activityType: ActivityType, title: string, body: string): Promise<{ summary: string }>`
+- アクティビティタイプ別のプロンプトを使用
+- JSON Schemaによるレスポンス形式の指定
+
+#### SummarizationAdapter の仕様
+
+- OpenAI APIの`gpt-4o-mini`モデルを使用（TranslationAdapterと同様）
+- プロンプト: アクティビティタイプに応じた要約指示
+- エラーハンドリング: TranslationAdapterと同様の実装
+- リトライ機構: TranslationAdapterと同様
+
+### Phase 3: Repository層の更新
+
+#### updateTranslationAndSummary() の仕様
+
+```typescript
+updateTranslationAndSummary(
+  activityId: ActivityId,
+  translatedTitle: string | null,
+  summary: string | null,
+  status: ActivityStatus,
+  statusDetail: string | null
+): Promise<void>
+```
+
+### Phase 4: UseCase層の更新
+
+#### processActivity() の更新内容
+
+1. OpenAI設定の取得（try-catch）
+2. OpenAI設定がある場合:
+   - 翻訳を実行（TranslationPort）
+   - 要約を実行（SummarizationPort）
+   - updateTranslationAndSummary()で更新
+3. OpenAI設定がない場合:
+   - 翻訳・要約をスキップ
+   - status=COMPLETEDで保存（translatedTitle, summaryはNULL）
+
+## 実装完了内容
+
+### Phase 1: スキーマ・ドメイン層実装 ✅
+
+- `schema.ts`に新フィールド追加（translatedTitle, summary, translatedBody）
+- Drizzle Kitでマイグレーションファイル生成（0010_volatile_typhoid_mary.sql）
+- `Activity`型に新フィールド追加
+- ローカルDBでマイグレーション実行・確認
+
+### Phase 2: 要約機能の実装（Port/Adapter） ✅
+
+- `SummarizationPort`の定義
+- `SummarizationAdapter`の実装（OpenAI APIを使った要約生成）
+- `SummarizationStubAdapter`の実装（テスト用）
+
+### Phase 3: Repository層の更新 ✅
+
+- `ActivityRepository`インターフェースの更新
+  - `upsert()`、`upsertMany()`のパラメータに翻訳・要約フィールドを追加
+  - `updateWithTranslation()`を`updateTranslationAndSummary()`に置き換え
+- `DrizzleActivityRepository`の実装更新
+  - 新フィールドのマッピング対応
+  - `mapToDomain()`の更新
+
+### Phase 4: UseCase層の更新 ✅
+
+- `ProcessUpdatesUseCase`の更新
+  - コンストラクタに`SummarizationPort`を追加
+  - `processActivity()`メソッドで翻訳・要約を両方実行
+  - OpenAI設定未取得時のフォールバック処理実装
+
+### Phase 5: Worker層の更新 ✅
+
+- `process-updates/handler.ts`の更新
+  - OpenAI設定取得のエラーハンドリング
+  - `SummarizationAdapter`のインスタンス化
+  - `ProcessUpdatesUseCase`への依存注入
+
+### Phase 6: テストの更新・実行 ✅
+
+- `handler.test.ts`の更新
+  - 新フィールドのテストデータ追加
+  - SummarizationAdapterのモック追加
+  - OpenAI APIキー未設定時のテストを仕様に合わせて修正
+- lint、format、test全て成功
+
+## 懸念事項・メモ
+
+### 現時点での懸念
+
+なし（全ての実装とテストが完了し、正常に動作しています）
+
+### 実装時の注意点
+
+1. 原文（title, body）は保持され、翻訳済みタイトル（translatedTitle）、要約（summary）は別フィールドで管理
+2. translatedBodyは今回はNULLとして保存（将来の拡張用）
+3. OpenAI APIキー未設定時は翻訳・要約をスキップし、status=COMPLETEDで処理継続
+4. 既存データへの影響なし（新規フィールドは全てNULL許可）
+
+## 作業履歴
+
+### 2025-10-26
+
+- 作業ログ作成
+- 実装計画の策定
+- Phase 1-6 全て完了
+- lint、format、test 全て成功

--- a/packages/backend/src/db/migrations/0010_volatile_typhoid_mary.sql
+++ b/packages/backend/src/db/migrations/0010_volatile_typhoid_mary.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "activities" ADD COLUMN "translated_title" text;--> statement-breakpoint
+ALTER TABLE "activities" ADD COLUMN "summary" text;--> statement-breakpoint
+ALTER TABLE "activities" ADD COLUMN "translated_body" text;

--- a/packages/backend/src/db/migrations/meta/0010_snapshot.json
+++ b/packages/backend/src/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,2049 @@
+{
+  "id": "78325cab-e785-4f34-8842-d32461ade6f8",
+  "prevId": "5ec2121a-0f2c-4a16-82bb-54276a462795",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activities": {
+      "name": "activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_event_id": {
+          "name": "github_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_data": {
+          "name": "github_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translated_title": {
+          "name": "translated_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translated_body": {
+          "name": "translated_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activities_data_source_github_activity_type_unique": {
+          "name": "activities_data_source_github_activity_type_unique",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activities_data_source_id": {
+          "name": "idx_activities_data_source_id",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activities_type": {
+          "name": "idx_activities_type",
+          "columns": [
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activities_title": {
+          "name": "idx_activities_title",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activities_version": {
+          "name": "idx_activities_version",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activities_github_event_id": {
+          "name": "idx_activities_github_event_id",
+          "columns": [
+            {
+              "expression": "github_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activities_data_source_type": {
+          "name": "idx_activities_data_source_type",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activities_data_source_created": {
+          "name": "idx_activities_data_source_created",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activities_status": {
+          "name": "idx_activities_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activities_created_at": {
+          "name": "idx_activities_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activities_updated_at": {
+          "name": "idx_activities_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activities_data_source_id_data_sources_id_fk": {
+          "name": "activities_data_source_id_data_sources_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "data_sources",
+          "columnsFrom": ["data_source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bookmark_type": {
+          "name": "bookmark_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_bookmark_target_unique": {
+          "name": "bookmarks_user_bookmark_target_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bookmark_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookmarks_user_id": {
+          "name": "idx_bookmarks_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookmarks_target_id": {
+          "name": "idx_bookmarks_target_id",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookmarks_type_target": {
+          "name": "idx_bookmarks_type_target",
+          "columns": [
+            {
+              "expression": "bookmark_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookmarks_user_type": {
+          "name": "idx_bookmarks_user_type",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bookmark_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookmarks_created_at": {
+          "name": "idx_bookmarks_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_sources": {
+      "name": "data_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_sources_source_type_source_id_unique": {
+          "name": "data_sources_source_type_source_id_unique",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_data_sources_type": {
+          "name": "idx_data_sources_type",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_data_sources_source_id": {
+          "name": "idx_data_sources_source_id",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_data_sources_name": {
+          "name": "idx_data_sources_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_data_sources_created_at": {
+          "name": "idx_data_sources_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_data_sources_updated_at": {
+          "name": "idx_data_sources_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_digest_entries": {
+      "name": "notification_digest_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_source_name": {
+          "name": "data_source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generator": {
+          "name": "generator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_digest_entries_notification_id": {
+          "name": "idx_notification_digest_entries_notification_id",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_digest_entries_data_source_id": {
+          "name": "idx_notification_digest_entries_data_source_id",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_digest_entries_activity_id": {
+          "name": "idx_notification_digest_entries_activity_id",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_digest_entries_unique": {
+          "name": "notification_digest_entries_unique",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_digest_entries_notification_id_notifications_id_fk": {
+          "name": "notification_digest_entries_notification_id_notifications_id_fk",
+          "tableFrom": "notification_digest_entries",
+          "tableTo": "notifications",
+          "columnsFrom": ["notification_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_digest_entries_data_source_id_data_sources_id_fk": {
+          "name": "notification_digest_entries_data_source_id_data_sources_id_fk",
+          "tableFrom": "notification_digest_entries",
+          "tableTo": "data_sources",
+          "columnsFrom": ["data_source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_digest_entries_activity_id_activities_id_fk": {
+          "name": "notification_digest_entries_activity_id_activities_id_fk",
+          "tableFrom": "notification_digest_entries",
+          "tableTo": "activities",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_digest_user_states": {
+      "name": "notification_digest_user_states",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_successful_run_at": {
+          "name": "last_successful_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_run_at": {
+          "name": "last_attempted_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_digest_user_states_last_successful_run_at": {
+          "name": "idx_notification_digest_user_states_last_successful_run_at",
+          "columns": [
+            {
+              "expression": "last_successful_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_digest_user_states_user_id_users_id_fk": {
+          "name": "notification_digest_user_states_user_id_users_id_fk",
+          "tableFrom": "notification_digest_user_states",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'activity_digest'"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id": {
+          "name": "idx_notifications_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_activity_id": {
+          "name": "idx_notifications_activity_id",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_is_read": {
+          "name": "idx_notifications_is_read",
+          "columns": [
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_notification_type": {
+          "name": "idx_notifications_notification_type",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_scheduled_at": {
+          "name": "idx_notifications_scheduled_at",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_status": {
+          "name": "idx_notifications_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_read": {
+          "name": "idx_notifications_user_read",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_created": {
+          "name": "idx_notifications_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_sent_at": {
+          "name": "idx_notifications_sent_at",
+          "columns": [
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_created_at": {
+          "name": "idx_notifications_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_updated_at": {
+          "name": "idx_notifications_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_activity_unique": {
+          "name": "notifications_user_activity_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_activity_id_activities_id_fk": {
+          "name": "notifications_activity_id_activities_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "activities",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stars_count": {
+          "name": "stars_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forks_count": {
+          "name": "forks_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "open_issues_count": {
+          "name": "open_issues_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_fork": {
+          "name": "is_fork",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_repositories_data_source_id": {
+          "name": "idx_repositories_data_source_id",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repositories_github_id": {
+          "name": "idx_repositories_github_id",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repositories_full_name": {
+          "name": "idx_repositories_full_name",
+          "columns": [
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repositories_language": {
+          "name": "idx_repositories_language",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repositories_stars_count": {
+          "name": "idx_repositories_stars_count",
+          "columns": [
+            {
+              "expression": "stars_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repositories_created_at": {
+          "name": "idx_repositories_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repositories_updated_at": {
+          "name": "idx_repositories_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repositories_data_source_id_data_sources_id_fk": {
+          "name": "repositories_data_source_id_data_sources_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "data_sources",
+          "columnsFrom": ["data_source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repositories_github_id_unique": {
+          "name": "repositories_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["github_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "logged_in_at": {
+          "name": "logged_in_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_email": {
+          "name": "idx_sessions_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "digest_delivery_times": {
+          "name": "digest_delivery_times",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"18:00\"]'::jsonb"
+        },
+        "digest_timezone": {
+          "name": "digest_timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_enabled": {
+          "name": "digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_preferences_user_id": {
+          "name": "idx_user_preferences_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_preferences_created_at": {
+          "name": "idx_user_preferences_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_preferences_updated_at": {
+          "name": "idx_user_preferences_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_watches": {
+      "name": "user_watches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_enabled": {
+          "name": "notification_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watch_releases": {
+          "name": "watch_releases",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watch_issues": {
+          "name": "watch_issues",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watch_pull_requests": {
+          "name": "watch_pull_requests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_watches_user_id_data_source_id_unique": {
+          "name": "user_watches_user_id_data_source_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_watches_user_id": {
+          "name": "idx_user_watches_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_watches_data_source_id": {
+          "name": "idx_user_watches_data_source_id",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_watches_added_at": {
+          "name": "idx_user_watches_added_at",
+          "columns": [
+            {
+              "expression": "added_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_watches_user_id_users_id_fk": {
+          "name": "user_watches_user_id_users_id_fk",
+          "tableFrom": "user_watches",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_watches_data_source_id_data_sources_id_fk": {
+          "name": "user_watches_data_source_id_data_sources_id_fk",
+          "tableFrom": "user_watches",
+          "tableTo": "data_sources",
+          "columnsFrom": ["data_source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "auth0_user_id": {
+          "name": "auth0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_auth0_user_id": {
+          "name": "idx_users_auth0_user_id",
+          "columns": [
+            {
+              "expression": "auth0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_github_username": {
+          "name": "idx_users_github_username",
+          "columns": [
+            {
+              "expression": "github_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_created_at": {
+          "name": "idx_users_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_updated_at": {
+          "name": "idx_users_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth0_user_id_unique": {
+          "name": "users_auth0_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["auth0_user_id"]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/backend/src/db/migrations/meta/_journal.json
+++ b/packages/backend/src/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1760980780855,
       "tag": "0009_digest_notification_unification",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1761413786387,
+      "tag": "0010_volatile_typhoid_mary",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/src/db/schema.ts
+++ b/packages/backend/src/db/schema.ts
@@ -155,6 +155,9 @@ export const activities = pgTable(
     status: text("status").notNull().default("pending"),
     statusDetail: text("status_detail"),
     githubData: text("github_data"),
+    translatedTitle: text("translated_title"),
+    summary: text("summary"),
+    translatedBody: text("translated_body"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
     updatedAt: timestamp("updated_at", { withTimezone: true })
       .defaultNow()

--- a/packages/backend/src/features/activities/domain/activity.ts
+++ b/packages/backend/src/features/activities/domain/activity.ts
@@ -57,6 +57,9 @@ export type ActivityRecord = {
   status: ActivityStatus
   statusDetail: string | null
   githubData: string | null
+  translatedTitle: string | null
+  summary: string | null
+  translatedBody: string | null
   createdAt: Date
   updatedAt: Date
 }

--- a/packages/backend/src/features/detection/application/ports/summarization.port.ts
+++ b/packages/backend/src/features/detection/application/ports/summarization.port.ts
@@ -1,0 +1,32 @@
+import { ACTIVITY_TYPE, type ActivityType } from "../../domain/activity"
+
+export interface SummarizationResponse {
+  summary: string
+}
+
+export interface SummarizationOptions {
+  model?: string
+  maxTokens?: number
+}
+
+export const SUMMARIZATION_PROMPTS = {
+  [ACTIVITY_TYPE.RELEASE]: `以下の<user-input>タグ内のリリースノートを簡潔に要約してください。
+主要な変更点、新機能、重要なバグ修正を箇条書きでまとめてください。
+開発者が一目で変更内容を把握できるよう、100-200文字程度で要約してください。`,
+
+  [ACTIVITY_TYPE.ISSUE]: `以下の<user-input>タグ内のIssue内容を簡潔に要約してください。
+問題の本質と解決策を端的にまとめてください。
+開発者が素早く内容を理解できるよう、100-200文字程度で要約してください。`,
+
+  [ACTIVITY_TYPE.PULL_REQUEST]: `以下の<user-input>タグ内のPR内容を簡潔に要約してください。
+主な変更内容と影響範囲を端的にまとめてください。
+開発者が変更の概要を素早く理解できるよう、100-200文字程度で要約してください。`,
+} as const
+
+export interface SummarizationPort {
+  summarize(
+    activityType: ActivityType,
+    title: string,
+    body: string,
+  ): Promise<SummarizationResponse>
+}

--- a/packages/backend/src/features/detection/domain/repositories/activity.repository.ts
+++ b/packages/backend/src/features/detection/domain/repositories/activity.repository.ts
@@ -17,6 +17,9 @@ export interface ActivityRepository {
     status?: ActivityStatus
     statusDetail?: string | null
     githubData?: string | null
+    translatedTitle?: string | null
+    summary?: string | null
+    translatedBody?: string | null
     createdAt: Date
   }): Promise<{ id: string; isNew: boolean }>
 
@@ -35,6 +38,9 @@ export interface ActivityRepository {
       status?: ActivityStatus
       statusDetail?: string | null
       githubData?: string | null
+      translatedTitle?: string | null
+      summary?: string | null
+      translatedBody?: string | null
       createdAt: Date
     }>,
   ): Promise<{ newActivityIds: string[]; updatedCount: number }>
@@ -62,12 +68,12 @@ export interface ActivityRepository {
   ): Promise<boolean>
 
   /**
-   * 翻訳結果とステータスを更新
+   * 翻訳済みタイトルと要約を更新（原文は保持）
    */
-  updateWithTranslation(
+  updateTranslationAndSummary(
     activityId: string,
-    translatedTitle: string,
-    translatedBody: string,
+    translatedTitle: string | null,
+    summary: string | null,
     status: ActivityStatus,
     statusDetail?: string | null,
   ): Promise<boolean>

--- a/packages/backend/src/features/detection/infra/adapters/summarization/summarization-stub.adapter.ts
+++ b/packages/backend/src/features/detection/infra/adapters/summarization/summarization-stub.adapter.ts
@@ -1,0 +1,21 @@
+import { SummarizationResponse } from "../../../application/ports/summarization.port"
+import { type ActivityType } from "../../../domain/activity"
+
+/**
+ * SummarizationServiceのスタブ実装
+ * テスト用およびローカル開発環境用
+ */
+export class SummarizationAdapterStub {
+  async summarize(
+    activityType: ActivityType,
+    title: string,
+    body: string,
+  ): Promise<SummarizationResponse> {
+    // スタブ実装: 固定の要約を返す
+    const truncatedBody =
+      body.length > 50 ? body.substring(0, 50) + "..." : body
+    return {
+      summary: `[要約] ${title} - ${truncatedBody}\n※これはテスト用のスタブ要約です。実際のAI要約は本番環境で実行されます。`,
+    }
+  }
+}

--- a/packages/backend/src/features/detection/infra/adapters/summarization/summarization.adapter.ts
+++ b/packages/backend/src/features/detection/infra/adapters/summarization/summarization.adapter.ts
@@ -1,0 +1,130 @@
+import OpenAI from "openai"
+import { type ActivityType } from "../../../domain/activity"
+import {
+  SUMMARIZATION_PROMPTS,
+  SummarizationOptions,
+  SummarizationPort,
+  SummarizationResponse,
+} from "../../../application/ports/summarization.port"
+
+export class SummarizationAdapter implements SummarizationPort {
+  private openai: OpenAI
+  private defaultOptions: SummarizationOptions = {
+    model: "gpt-4o-mini",
+    maxTokens: 500,
+  }
+
+  constructor(apiKey: string, options: SummarizationOptions = {}) {
+    this.openai = new OpenAI({
+      apiKey,
+    })
+    this.defaultOptions = { ...this.defaultOptions, ...options }
+  }
+
+  async summarize(
+    activityType: ActivityType,
+    title: string,
+    body: string,
+  ): Promise<SummarizationResponse> {
+    try {
+      // セキュリティ対策: プロンプトインジェクション防止のためのテキスト前処理
+      const sanitizedTitle = this.sanitizeInput(title)
+      const sanitizedBody = this.sanitizeInput(body)
+
+      const systemPrompt = SUMMARIZATION_PROMPTS[activityType]
+      const userContent = `<user-input>\nTitle: ${sanitizedTitle}\nBody: ${sanitizedBody}\n</user-input>`
+
+      const response = await this.openai.chat.completions.create({
+        model: this.defaultOptions.model!,
+        messages: [
+          {
+            role: "system",
+            content: systemPrompt,
+          },
+          {
+            role: "user",
+            content: userContent,
+          },
+        ],
+        response_format: {
+          type: "json_schema",
+          json_schema: {
+            name: "summarization_result",
+            schema: {
+              type: "object",
+              properties: {
+                summary: {
+                  type: "string",
+                  description: "要約された内容",
+                },
+              },
+              required: ["summary"],
+              additionalProperties: false,
+            },
+          },
+        },
+        max_tokens: this.defaultOptions.maxTokens,
+        temperature: 0.3, // 一貫性のある要約のため低めに設定
+      })
+
+      const content = response.choices[0]?.message?.content
+      if (!content) {
+        throw new Error("OpenAI API returned empty response")
+      }
+
+      const result = JSON.parse(content) as SummarizationResponse
+
+      // レスポンス検証
+      if (!result.summary) {
+        throw new Error("Invalid summarization response format")
+      }
+
+      return result
+    } catch (error) {
+      if (error instanceof OpenAI.APIError) {
+        if (error.status === 429) {
+          throw new Error("OpenAI API rate limit exceeded")
+        }
+        if (error.status === 400) {
+          throw new Error("Invalid summarization request")
+        }
+        if (error.status === 401) {
+          throw new Error("OpenAI API authentication failed")
+        }
+        throw new Error(`OpenAI API error: ${error.message}`)
+      }
+
+      if (error instanceof SyntaxError) {
+        throw new Error("Failed to parse OpenAI API response")
+      }
+
+      if (error instanceof Error) {
+        throw new Error(`Summarization service error: ${error.message}`)
+      }
+
+      throw new Error("Summarization service error: Unknown error")
+    }
+  }
+
+  /**
+   * プロンプトインジェクション対策のための入力テキストサニタイズ
+   * <user-input>、</user-input> タグを削除して悪意のあるプロンプト注入を防ぐ
+   */
+  private sanitizeInput(text: string): string {
+    return text
+      .replace(/<user-input>/gi, "")
+      .replace(/<\/user-input>/gi, "")
+      .trim()
+  }
+}
+
+/**
+ * SummarizationServiceのファクトリー関数
+ * テスト時にスタブインスタンスを差し替えやすくするため
+ */
+export function createSummarizationService(
+  apiKey: string,
+  options: SummarizationOptions = {},
+): SummarizationAdapter {
+  return new SummarizationAdapter(apiKey, options)
+}

--- a/packages/backend/src/features/detection/infra/repositories/drizzle-activity.repository.ts
+++ b/packages/backend/src/features/detection/infra/repositories/drizzle-activity.repository.ts
@@ -30,6 +30,9 @@ export class DrizzleActivityRepository implements ActivityRepository {
     status?: ActivityStatus
     statusDetail?: string | null
     githubData?: string | null
+    translatedTitle?: string | null
+    summary?: string | null
+    translatedBody?: string | null
     createdAt: Date
   }): Promise<{ id: string; isNew: boolean }> {
     const now = new Date()
@@ -47,6 +50,9 @@ export class DrizzleActivityRepository implements ActivityRepository {
       status: data.status || ACTIVITY_STATUS.PENDING,
       statusDetail: data.statusDetail ?? null,
       githubData: data.githubData ?? null,
+      translatedTitle: data.translatedTitle ?? null,
+      summary: data.summary ?? null,
+      translatedBody: data.translatedBody ?? null,
       createdAt: data.createdAt,
       updatedAt: now,
     } as const
@@ -68,6 +74,9 @@ export class DrizzleActivityRepository implements ActivityRepository {
           status: insertData.status,
           statusDetail: insertData.statusDetail,
           githubData: insertData.githubData,
+          translatedTitle: insertData.translatedTitle,
+          summary: insertData.summary,
+          translatedBody: insertData.translatedBody,
           updatedAt: insertData.updatedAt,
         },
       })
@@ -93,6 +102,9 @@ export class DrizzleActivityRepository implements ActivityRepository {
       status?: ActivityStatus
       statusDetail?: string | null
       githubData?: string | null
+      translatedTitle?: string | null
+      summary?: string | null
+      translatedBody?: string | null
       createdAt: Date
     }>,
   ): Promise<{ newActivityIds: string[]; updatedCount: number }> {
@@ -113,6 +125,9 @@ export class DrizzleActivityRepository implements ActivityRepository {
       status: data.status || ACTIVITY_STATUS.PENDING,
       statusDetail: data.statusDetail ?? null,
       githubData: data.githubData ?? null,
+      translatedTitle: data.translatedTitle ?? null,
+      summary: data.summary ?? null,
+      translatedBody: data.translatedBody ?? null,
       createdAt: data.createdAt,
       updatedAt: now,
     }))
@@ -134,6 +149,9 @@ export class DrizzleActivityRepository implements ActivityRepository {
           status: sql`excluded.status`,
           statusDetail: sql`excluded.status_detail`,
           githubData: sql`excluded.github_data`,
+          translatedTitle: sql`excluded.translated_title`,
+          summary: sql`excluded.summary`,
+          translatedBody: sql`excluded.translated_body`,
           updatedAt: sql`excluded.updated_at`,
         },
       })
@@ -208,12 +226,12 @@ export class DrizzleActivityRepository implements ActivityRepository {
   }
 
   /**
-   * 翻訳結果とステータスを更新
+   * 翻訳済みタイトルと要約を更新（原文は保持）
    */
-  async updateWithTranslation(
+  async updateTranslationAndSummary(
     activityId: string,
-    translatedTitle: string,
-    translatedBody: string,
+    translatedTitle: string | null,
+    summary: string | null,
     status: ActivityStatus,
     statusDetail?: string | null,
   ): Promise<boolean> {
@@ -223,8 +241,8 @@ export class DrizzleActivityRepository implements ActivityRepository {
     const result = await connection
       .update(activities)
       .set({
-        title: translatedTitle,
-        body: translatedBody,
+        translatedTitle,
+        summary,
         status,
         statusDetail,
         updatedAt: now,
@@ -339,6 +357,9 @@ export class DrizzleActivityRepository implements ActivityRepository {
       status: row.status as ActivityStatus,
       statusDetail: row.statusDetail,
       githubData: row.githubData,
+      translatedTitle: row.translatedTitle,
+      summary: row.summary,
+      translatedBody: row.translatedBody,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
     }


### PR DESCRIPTION
## 概要

Activityテーブルのスキーマを拡張し、原文と翻訳/要約を併存できるようにしました。

## 変更内容

### スキーマ変更
- `activities`テーブルに翻訳・要約フィールドを追加
  - `translatedTitle`: 翻訳済みタイトル（日本語）
  - `summary`: 本文要約（日本語、AIによる要約）
  - `translatedBody`: 翻訳済み本文（将来の拡張用、今回はNULL）

### 新規機能
- 要約生成機能を実装
  - `SummarizationPort`（ポート定義）
  - `SummarizationAdapter`（OpenAI APIを使った実装）
  - `SummarizationAdapterStub`（テスト用スタブ）

### 既存機能の改善
- `ProcessUpdatesUseCase`の更新
  - 翻訳に加えて要約も生成
  - OpenAI APIキー未設定時のフォールバック処理
    - 翻訳・要約をスキップし、`status=COMPLETED`で処理継続

- `ActivityRepository`の更新
  - `updateWithTranslation()`を削除
  - `updateTranslationAndSummary()`を追加（原文を保持）

## テスト

- ✅ 既存テストを新仕様に対応
- ✅ OpenAI APIキー未設定時のテストを追加
- ✅ 全てのテストが成功（169 passed | 3 skipped）
- ✅ lint、format 全て成功

## 影響範囲

- ✅ 既存データへの影響なし（新規フィールドは全てNULL許可）
- ✅ 原文（`title`, `body`）は保持され、翻訳結果で上書きされない
- ✅ 後方互換性を保ったまま新機能を追加

## 受け入れ基準

- ✅ Activityに原文（`title`, `body`）と翻訳済みタイトル（`translatedTitle`）、本文要約（`summary`）が同時に保存されること
- ✅ 翻訳済み本文（`translatedBody`）はNULLであること
- ✅ OpenAI APIキー未設定時は翻訳・要約をNULLのまま処理が継続され、ステータスが`COMPLETED`になること
- ✅ 原文が翻訳結果で上書きされないこと
- ✅ 要約がアクティビティタイプに応じた適切な内容であること

## 関連資料

- SOW: `docs/sow/20251026-CHASE-140.md`
- 作業ログ: `docs/task-logs/CHASE-140/20251026-01-log.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)