### PR TITLE
CHASE-139 ヘッダとサイドバーの固定化およびブラー適用

### DIFF
--- a/packages/frontend/components/base/layouts/ClHeader.vue
+++ b/packages/frontend/components/base/layouts/ClHeader.vue
@@ -25,7 +25,9 @@ const showHamburger = computed(() => isLoggedIn.value)
 </script>
 
 <template>
-  <header class="bg-header-default shadow-sm border-b border-header-default">
+  <header
+    class="fixed inset-x-0 top-0 z-50 bg-header-default shadow-sm border-b border-header-default backdrop-blur-md"
+  >
     <div class="w-full px-2">
       <div class="flex justify-between items-center h-16">
         <!-- Left side: Brand and hamburger -->

--- a/packages/frontend/components/base/layouts/default/ClLayoutDefault.vue
+++ b/packages/frontend/components/base/layouts/default/ClLayoutDefault.vue
@@ -13,6 +13,18 @@ const props = withDefaults(defineProps<Props>(), {
 const sidebarOpen = ref(false)
 const isMobile = ref(false)
 
+const mainClasses = computed(() => {
+  const classes = [
+    'flex-1 min-h-[calc(100vh-4rem)] transition-[margin] duration-300',
+  ]
+
+  if (!isMobile.value) {
+    classes.push(sidebarOpen.value ? 'md:ml-64' : 'md:ml-[3.4rem]')
+  }
+
+  return classes
+})
+
 const toggleSidebar = () => {
   sidebarOpen.value = !sidebarOpen.value
 }
@@ -49,24 +61,20 @@ watch(isMobile, (newIsMobile) => {
 
 <template>
   <div class="min-h-screen bg-content-default">
-    <!-- Header -->
     <ClHeader
       :brand-text="props.brandText"
       :sidebar-open="sidebarOpen"
       @toggle-sidebar="toggleSidebar"
     />
 
-    <div class="flex h-[calc(100vh-4rem)]">
-      <!-- 4rem = header height (h-16) -->
-      <!-- Sidebar -->
+    <div class="pt-16">
       <ClSidebar
         :is-open="sidebarOpen"
         :is-mobile="isMobile"
         @close="closeSidebar"
       />
 
-      <!-- Main content -->
-      <main class="flex-1 overflow-y-auto">
+      <main :class="mainClasses">
         <div class="p-4 sm:p-6 lg:p-8">
           <slot />
         </div>

--- a/packages/frontend/components/base/layouts/default/ClSidebar.vue
+++ b/packages/frontend/components/base/layouts/default/ClSidebar.vue
@@ -76,7 +76,7 @@ watch(
   >
     <div
       v-if="isOpen"
-      class="fixed inset-0 z-40 bg-dialog-backdrop bg-opacity-50"
+      class="fixed inset-x-0 top-16 bottom-0 z-40 bg-dialog-backdrop bg-opacity-50"
       @click="handleBackdropClick"
     />
   </Transition>
@@ -94,12 +94,12 @@ watch(
       v-if="!isMobile || isOpen"
       ref="sidebarRef"
       :class="[
-        'bg-sidebar-default border-r border-sidebar-default transition-all duration-300',
+        'bg-sidebar-default border-r border-sidebar-default transition-all duration-300 overflow-y-auto overflow-x-hidden',
         isMobile
-          ? 'fixed inset-y-0 left-0 z-50 w-64 overflow-y-auto'
+          ? 'fixed top-16 bottom-0 left-0 z-50 w-64'
           : isCollapsed
-            ? 'w-[3.4rem] overflow-hidden'
-            : 'w-64 overflow-y-auto',
+            ? 'fixed top-16 left-0 z-40 h-[calc(100vh-4rem)] w-[3.4rem]'
+            : 'fixed top-16 left-0 z-40 h-[calc(100vh-4rem)] w-64',
       ]"
       :aria-hidden="isMobile && !isOpen"
       role="navigation"


### PR DESCRIPTION
## 背景
- CHASE-139 の要件に沿って、ヘッダとサイドバーをページ上部で固定し、ページ全体でスクロールするようレイアウトを見直しました。
- スクロール時にヘッダがコンテンツと重なるため、視認性向上のためのブラー表現も求められていました。

## 変更内容
- `ClHeader` を `fixed` 配置に変更し、`backdrop-blur-md` を適用して半透明ヘッダの視覚的フィードバックを追加。
- `ClLayoutDefault` で内部スクロールを廃止し、ヘッダ高さ・サイドバー幅に応じてメインコンテンツのレイアウトを調整。
- `ClSidebar` をヘッダ直下に固定し、モバイルでもヘッダの下からスライド表示されるように再配置。

## テスト
- `pnpm --filter frontend lint`
- `pnpm --filter frontend test`

## 確認結果

PC
<img width="1545" height="192" alt="image" src="https://github.com/user-attachments/assets/9207265f-ef30-4e25-a990-cb7a6982b0cf" />

モバイル
<img width="448" height="336" alt="image" src="https://github.com/user-attachments/assets/b732cf4b-01a0-42f1-b18d-7482ad70eaf1" />
