### PR TITLE
CHASE-170: ActivityDetail Repository導入とテスト安定化

### DIFF
--- a/docs/sow/20251130-CHASE-170.md
+++ b/docs/sow/20251130-CHASE-170.md
@@ -1,0 +1,263 @@
+# SOW: CHASE-170: ActivityDetailPage の Repository 導入とテスト修正
+
+## プロジェクト概要
+
+**課題ID**: CHASE-170  
+**作成日**: 2025-11-30  
+**種別**: バグ修正 / 実装改善
+
+## 1. 背景と目的
+
+### 背景
+
+- `packages/frontend/components/pages/activities/detail/__tests__/activity-detail.test.ts` が `useFetch` で `/api/activities/:id` を呼び出す際に API ルートが 404 となり、MSW でのモックも効かずタイムアウトしている。現状の `useFetch` + BFF 依存では Vitest 環境でのルーティング/フェッチ解決が不安定。
+- CHASE-170 では、この問題を解消するため「フロント側に Repository 層を挟み、ページは Repository を通じてデータ取得する」方針が示されている。
+- 既存ドキュメント（API/Page実装ガイド、フォルダ構成、テスト戦略）も BFF 直接呼び出し前提であり、Repository 導入方針を反映できていない。
+
+### 目的
+
+- Activity Detail ページのデータ取得を Repository 経由に置き換え、Vitest でも安定してモック可能にする。
+- それに伴うテスト修正と、ガイドライン類への方針反映を行い、今後の同様実装の足場を整える。
+
+## 2. 実装スコープ
+
+### 実装対象
+
+- フロントエンド Activity Detail ページ周辺（`pages/activities/[id].vue` / `components/pages/activities/detail/*`）
+- フロントエンド用 Repository（Activity Detail 向け新設）
+- 関連ドキュメント（API実装 / ページ実装 / フォルダ構成 / テスト戦略）
+
+### 更新可能な項目
+
+1. Activity Detail 用 Repository の新設と DI/参照箇所の組み込み
+2. Activity Detail ページ（`ActivityDetailPage.vue` 等）のデータ取得ロジックを Repository 利用へ切り替え
+3. Activity Detail のページテスト修正（Repository をモックし、翻訳トグル等の UI 検証を安定化）
+4. ガイドライン類の更新（Repository 導入方針とテストモック手順の追記）
+
+### 実装除外項目
+
+- Backend（Hono）側の API 実装変更
+- 他ページ/他ドメインの Repository 化やリファクタ全般
+- E2E テスト追加・大規模な UI 改修
+
+## 3. 技術仕様
+
+### API仕様
+
+- ページコンポーネントは useAsyncData経由でRepositoryのfetchメソッドを呼び出す
+- Repositoryは Nuxt.jsのAPIルートの `/api/activities/:id` を呼び出す。受け取ったレスポンスをフロントエンド用の型に変換する
+- Nuxt.jsのAPIルートでは、既存のHonoバックエンドの `/activities/:id` エンドポイントを呼び出す(現在の実装のまま)
+
+### データベース操作
+
+- なし（フロントのみの変更。Backend 側の永続化処理は現行のまま利用）。
+
+### アーキテクチャ設計
+
+- フロントエンドに Activity 向け Repository 層を追加し、`ActivityDetailPage` は `useFetch` 直接呼び出しではなく Repository 経由でデータ取得する。
+- Repositoryは Nuxt.jsのAPIルートの `/api/activities/:id` を呼び出す。受け取ったレスポンスをフロントエンド用の型に変換する
+- テストでは Repository モジュールをモックすることで、Nuxt BFF ルートの有無に依存せず UI を検証。MSW ハンドラは Repository のネットワーク層が必要な場合にのみ使用。
+
+## 4. 実装ファイル一覧
+
+### 新規作成ファイル
+
+1. **`packages/frontend/features/activities/domain/activity.ts`**
+   - Activity Detail のフロントエンド用型定義（Orval 生成型のエイリアスまたはマッピングを集約）。
+2. **`packages/frontend/features/activities/repositories/activity-detail-repository.ts`**
+   - Activity Detail 取得メソッドを提供（Nuxt API ルート呼び出し + 型整形、必要に応じて Zod 検証）。
+
+### 更新対象ファイル
+
+1. **`packages/frontend/components/pages/activities/detail/ActivityDetailPage.vue`**
+   - `useFetch` 直呼び出しを Repository 利用へ置き換え、翻訳トグル等の既存 UI を維持。
+2. **`packages/frontend/components/pages/activities/detail/__tests__/activity-detail.test.ts`**
+   - Repository モックを使った安定化（データ注入、トグル動作検証）。
+3. **`packages/frontend/docs/guidelines/api-implementation-guide.md`**
+   - Repository を介したデータ取得方針の追記。
+4. **`packages/frontend/docs/guidelines/page-implementation-guide.md`**
+   - ページでのデータ取得に Repository/Composable を挟む指針を追記。
+5. **`packages/frontend/docs/guidelines/folder-structure.md`**
+   - 新設する `repositories/`（または同等ディレクトリ）を構成図・役割に追加。
+6. **`packages/frontend/docs/testing-strategy.md`**
+   - ページテストでの Repository モック方針、MSW との使い分けを追記。
+
+## 5. テスト戦略
+
+### Component Test（Presentation層）
+
+- Activity Detail 表示：タイトル/本文/リポジトリ名/アクションボタン数が期待どおり表示されること。
+- 翻訳トグル動作：翻訳本文⇔原文本文の切り替えとトグルラベルの変化を検証。
+- 翻訳無しケース：トグルが無効化され、原文のみ表示されること。
+- エラー/NotFound（Repository 経由での 404/500 の扱い）は別途ユニット or スナップショットで簡易確認（必要最小限）。
+
+### Unit Test（Repository層）
+
+- Repository層に対するテストはメンテナンスコストを考慮し、実装しない。(E2Eテストでカバーする想定)
+
+## 6. 受け入れ基準
+
+### 機能要件
+
+- [ ] Activity Detail ページが Repository 経由でデータ取得し、翻訳トグル含め UI が従来通り表示される。
+- [ ] `activity-detail.test.ts` が安定してパスし、タイムアウトしない。
+- [ ] Repository 層で Zod バリデーションにより取得データが検証される。
+
+### 非機能要件
+
+- [ ] `pnpm --filter frontend test` が通る。
+- [ ] 新設/変更ファイルがフォルダ構成・命名規約に従う。
+- [ ] `pnpm format` / `pnpm lint` でエラーが出ない想定で実装されている。
+
+### セキュリティ要件
+
+- [ ] Repository 経由のリクエストでセッション由来のアクセストークン付与（既存 `custom-fetch` 挙動）を阻害しない。
+- [ ] エラー時のレスポンスに内部情報を露出しない。
+
+## 7. 実装手順
+
+### Phase 1: Repository 層実装
+
+- 1-1. Activity Detail Repository を作成し、Orval クライアント + Zod での取得処理を実装。
+- 1-2. DI/エクスポートを整理し、ページ側で参照できるようにする。
+- 1-3. format, lint（必要なら部分実行）。
+
+### Phase 2: ページ実装の置き換え
+
+- 2-1. `ActivityDetailPage.vue` を Repository 利用に変更（`useFetch` 依存を除去、SSR/CSR 両対応）。
+- 2-2. ルートパラメータの取得/検証を整理し、テスト環境でも安定するようにする。
+- 2-3. format, lint。
+
+### Phase 3: テスト整備
+
+- 3-1. `activity-detail.test.ts` で Repository をモックし、データ注入と UI 検証を安定化。
+- 3-2. Repository 単体テストはスコープ外（Unit Test セクションの方針どおり今回は追加しない）。
+- 3-3. `pnpm --filter frontend test` 実行。
+
+### Phase 4: ドキュメント更新
+
+- 4-1. API/Page ガイドラインに Repository 導入方針と利用パターンを追記。
+- 4-2. フォルダ構成/テスト戦略に Repository ディレクトリとモック方針を反映。
+- 4-3. format, lint（該当する場合のみ）。
+
+## 9. リスク・考慮事項
+
+### 技術的リスク
+
+- Repository 追加により既存 BFF 方針との整合性が曖昧になる可能性。
+- `BACKEND_API_URL` 未設定環境での動作（Vitest 実行時）に注意が必要。
+- Repository のモック戦略が他テストと食い違うと、モックの重複/競合が起きる恐れ。
+
+### 軽減策
+
+- ガイドラインで「ページテストは Repository モックを優先、ネットワークは MSW と併用する条件を明記」し周知。
+- Vitest 用のデフォルト BASE URL（`http://localhost:3001` など）を Repository レイヤー内で許容するか、テスト側で環境変数をセットする手順を記述。
+- 今回の変更範囲を Activity Detail に限定し、他領域への適用は別課題で段階的に展開する。
+
+## 8. コード案（CHASE-170 の課題方針に基づく参考実装）
+
+### domain 層（新規）
+
+`packages/frontend/features/activities/domain/activity.ts`
+
+```typescript
+import type { ActivityDetail as BackendActivityDetail } from '@/generated/backend' // Orval 生成型を前提
+
+// フロントで利用する Activity 詳細型。API型と差がなければエイリアスで集約する。
+export type ActivityDetail = BackendActivityDetail
+
+// APIレスポンスとの差分が出た場合はここで整形用の型を定義し、Repository 内で map する。
+// 例:
+// export type ActivityDetail = {
+//   id: string
+//   title: string
+//   body: string
+//   translatedTitle: string | null
+//   translatedBody: string | null
+//   updatedAt: string
+// }
+```
+
+### Repository 層（新規）
+
+`packages/frontend/features/activities/repositories/activity-detail-repository.ts`
+
+```typescript
+import type { ActivityDetail } from '../domain/activity'
+
+class ActivityDetailRepository {
+  private fetcher = useRequestFetch()
+
+  async fetch(id: string): Promise<ActivityDetail> {
+    // Nuxt API ルートを経由して BFF → backend を呼び出す
+    const response = await this.fetcher<ActivityDetail>(`/api/activities/${id}`)
+    // 追加整形が必要な場合はここで map する
+    return response
+  }
+}
+
+export const activityDetailRepository = new ActivityDetailRepository()
+```
+
+### ページ実装の切り替え（Repository 利用）
+
+`packages/frontend/components/pages/activities/detail/ActivityDetailPage.vue`
+
+```typescript
+import { computed, ref, watchEffect } from "vue";
+import { activityDetailRepository } from "../../../features/activities/repositories/activity-detail-repository";
+
+const props = defineProps<{ activityId: string }>();
+
+const { data, error, pending } = await useAsyncData(
+  () => `activity-detail:${props.activityId}`,
+  () => activityDetailRepository.fetch(props.activityId),
+  { server: true, lazy: false },
+);
+
+if (error.value) throw error.value;
+const activity = computed(() => data.value);
+
+// 以下は既存ロジック（pageTitle, hasTranslatedContent, mode 切替など）をそのまま利用
+```
+
+`packages/frontend/pages/activities/[id].vue`
+
+```typescript
+const route = useRoute()
+const activityId = computed(() => route.params.id as string)
+
+<ActivityDetailPage :activity-id="activityId" />
+```
+
+### テストで Repository をモック
+
+`packages/frontend/components/pages/activities/detail/__tests__/activity-detail.test.ts`
+
+```typescript
+import { vi } from "vitest";
+
+vi.mock(
+  "../../../../../features/activities/repositories/activity-detail-repository",
+  () => {
+    return {
+      ActivityRepository: {
+        fetch: vi.fn().mockResolvedValue(buildActivity()),
+      },
+    };
+  },
+);
+
+// mountSuspended は route params を与えてページをマウント
+const Page = (await import("~/pages/activities/[id].vue")).default;
+await mountSuspended(Page, { route: { params: { id: activityId } } });
+```
+
+- 翻訳なしケースは `fetch.mockResolvedValue(buildActivity({ translatedBody: null, translatedTitle: null }))` のように差し替える。
+- Repository モックにより `/api/activities/:id` の BFF ルート有無に依存せずテストが通る。
+
+### ドキュメント更新のポイント
+
+- API/Page ガイドライン: 「ページは Repository/Composable を介してデータ取得し、BFF 直呼びは避ける（テスト容易性のため）」を明記。
+- フォルダ構成: `features/<feature>/repositories/` 追加、役割と配置例を追記。
+- テスト戦略: ページテストは Repository モックをデフォルトとし、ネットワーク前提が必要な場合のみ MSW を使用する旨を記述。

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -8,7 +8,7 @@ AUTH0_AUDIENCE=your-auth0-api-identifier
 NUXT_SESSION_SECRET=your-very-long-random-session-secret-key-here
 
 # Database Connection
-DATABASE_URL=postgresql://username:password@localhost:5432/database_name
+DATABASE_URL=postgresql://postgres:password@localhost:5432/chase_light
 
 # Application URL
 NUXT_PUBLIC_BASE_URL=http://localhost:3000
@@ -40,7 +40,7 @@ AUTH_DEBUG_SENSITIVE=false
 # ==============================================
 # Test Auth configuration (local/dev only)
 # ==============================================
-TEST_AUTH_ENABLED=false
+TEST_AUTH_ENABLED=true
 TEST_AUTH_SECRET=replace-with-a-random-secret
 TEST_AUTH_AUDIENCE=http://localhost:3001
 TEST_AUTH_ISSUER=http://localhost/test-auth

--- a/packages/frontend/.env.test
+++ b/packages/frontend/.env.test
@@ -1,0 +1,46 @@
+# Auth0 Configuration
+AUTH0_DOMAIN=your-auth0-domain.auth0.com
+AUTH0_CLIENT_ID=your-auth0-client-id
+AUTH0_CLIENT_SECRET=your-auth0-client-secret
+AUTH0_AUDIENCE=your-auth0-api-identifier
+
+# Session Secret (generate a random 32+ character string)
+NUXT_SESSION_SECRET=your-very-long-random-session-secret-key-here
+
+# Database Connection
+DATABASE_URL=postgresql://postgres:password@localhost:5432/chase_light_test
+
+# Application URL
+NUXT_PUBLIC_BASE_URL=http://localhost:3000
+
+# Backend API URL
+BACKEND_API_URL=http://localhost:3001
+
+# Environment
+NODE_ENV=test
+APP_STAGE=dev
+
+# ==============================================
+# 開発サーバーポート設定
+# ==============================================
+
+# フロントエンド開発サーバーポート番号
+# デフォルト: 3000
+# 複数環境で使う場合は例: 3001, 3002 など
+FRONTEND_PORT=3000
+
+# Authentication Logging Configuration
+# Log level for authentication operations (error/warn/info/debug)
+AUTH_LOG_LEVEL=info
+
+# Enable sensitive information logging for debugging (true/false)
+# Note: Automatically disabled in production environment
+AUTH_DEBUG_SENSITIVE=false
+
+# ==============================================
+# Test Auth configuration (local/dev only)
+# ==============================================
+TEST_AUTH_ENABLED=true
+TEST_AUTH_SECRET=replace-with-a-random-secret
+TEST_AUTH_AUDIENCE=http://localhost:3001
+TEST_AUTH_ISSUER=http://localhost/test-auth

--- a/packages/frontend/.gitignore
+++ b/packages/frontend/.gitignore
@@ -22,6 +22,7 @@ logs
 .env
 .env.*
 !.env.example
+!.env.test
 
 # Playwright
 /test-results/

--- a/packages/frontend/components/pages/activities/detail/ActivityDetailPage.vue
+++ b/packages/frontend/components/pages/activities/detail/ActivityDetailPage.vue
@@ -16,7 +16,7 @@ const mode = ref<DisplayMode>('translated')
 const activityDetailRepository = new ActivityDetailRepository()
 
 const fetchKey = computed(() => `activity-detail:${props.activityId}`)
-const { data, error, refresh } = await useAsyncData<ActivityDetail>(
+const { data, error } = await useAsyncData<ActivityDetail>(
   fetchKey,
   () => activityDetailRepository.fetch(props.activityId),
   {

--- a/packages/frontend/components/pages/activities/detail/ActivityDetailPage.vue
+++ b/packages/frontend/components/pages/activities/detail/ActivityDetailPage.vue
@@ -15,8 +15,9 @@ type DisplayMode = 'translated' | 'original'
 const mode = ref<DisplayMode>('translated')
 const activityDetailRepository = new ActivityDetailRepository()
 
-const { data, error } = await useAsyncData<ActivityDetail>(
-  () => `activity-detail:${props.activityId}`,
+const fetchKey = computed(() => `activity-detail:${props.activityId}`)
+const { data, error, refresh } = await useAsyncData<ActivityDetail>(
+  fetchKey,
   () => activityDetailRepository.fetch(props.activityId),
   {
     server: true,

--- a/packages/frontend/components/pages/activities/detail/parts/ActivityDetailHeader.vue
+++ b/packages/frontend/components/pages/activities/detail/parts/ActivityDetailHeader.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue'
 import ClButton from '~/components/base/ClButton.vue'
 import ClHeading from '~/components/base/ClHeading.vue'
-import type { ActivityDetailResponseData } from '~/generated/api/schemas'
+import type { ActivityDetail } from '~/features/activities/domain/activity'
 import { formatDate, formatRelativeDate } from '~/utils/date'
 
 const activityTypeLabels: Record<string, string> = {
@@ -18,7 +18,7 @@ const activityTypeClasses: Record<string, string> = {
 }
 
 const props = defineProps<{
-  activity: ActivityDetailResponseData['activity']
+  activity: ActivityDetail
   mode: 'translated' | 'original'
   hasTranslatedContent: boolean
 }>()

--- a/packages/frontend/docs/guidelines/folder-structure.md
+++ b/packages/frontend/docs/guidelines/folder-structure.md
@@ -24,8 +24,9 @@ packages/frontend
 │   └── guidelines/
 ├── features/              # 機能（ドメイン）単位の整理
 │   └── <feature>/
-│       ├── models/
-│       └── composables/
+│       ├── domain/        # フロントエンド用の型／マッピング
+│       ├── repositories/  # Nuxt API ルートを呼び出す Repository 層
+│       └── composables/   # 機能固有の composable
 ├── generated/             # Orval 自動生成コード（手動編集不可）
 │   └── api/
 ├── layouts/               # Nuxt レイアウト（例: default, guest）
@@ -53,7 +54,8 @@ packages/frontend
 - `components/common/`: 複数機能で再利用される中粒度UI（例: AppHeader.vue）。
 - `components/pages/<page>/`: ページ本体（`<PageName>Page.vue`）と `parts/`、ページ専用 composable（`use-<page>-page.ts`）を併置。
 - `composables/`: 横断的に再利用する composable を配置。
-- `features/<feature>/models`: 型、Zod スキーマ、型に特化した純関数（例: `user.ts`, `data-source.ts`）。
+- `features/<feature>/domain`: フロントエンド用の型やマッピング、必要に応じた純関数。
+- `features/<feature>/repositories`: Nuxt API ルート（`/api/*`）を呼び出す Repository。戻り値は `domain` の型。
 - `features/<feature>/composables`: 機能に特化した composable（例: `use-add-data-source.ts`）。
 - `pages/`: Nuxt のルート定義（薄いエントリ）。UI 本体は `components/pages/<page>/` 側に置く運用。
 - `layouts/`: Nuxt レイアウト（例: `default.vue`, `guest.vue`）。
@@ -80,4 +82,3 @@ packages/frontend
 - ページ実装ガイド: `packages/frontend/docs/guidelines/page-implementation-guide.md`
 - API 実装ガイド: `packages/frontend/docs/guidelines/api-implementation-guide.md`
 - テスト戦略（MSW 含む）: `packages/frontend/docs/testing-strategy.md`
-

--- a/packages/frontend/docs/testing-strategy.md
+++ b/packages/frontend/docs/testing-strategy.md
@@ -52,6 +52,7 @@
 
    - 依存 API が多いほどテストが速く安定。
    - ハンドラは `tests/mocks/handlers.ts` に集約し、開発中 `nuxt dev` でも共有。
+   - ページ／DOMテストで API 呼び出しを伴う場合は、まず `features/<feature>/repositories/*` をモックする（ネットワーク依存を避ける）。MSW は Repository 直下の通信が必要なケースのみ使用。
 
 2. **Browser Feature も基本 MSW**
 

--- a/packages/frontend/errors/http-error.ts
+++ b/packages/frontend/errors/http-error.ts
@@ -1,0 +1,83 @@
+// HTTP リクエストラッパー（features/shared/http/request-fetch.ts）向けのエラー正規化用
+export class HttpError extends Error {
+  readonly status: number
+  readonly data: unknown
+  readonly headers?: Headers
+
+  constructor({
+    status,
+    message,
+    data,
+    headers,
+  }: {
+    status: number
+    message?: string
+    data?: unknown
+    headers?: Headers
+  }) {
+    super(message ?? `HTTP ${status}`)
+    this.name = 'HttpError'
+    this.status = status
+    this.data = data
+    this.headers = headers
+  }
+
+  get isClientError(): boolean {
+    return this.status >= 400 && this.status < 500
+  }
+
+  get isServerError(): boolean {
+    return this.status >= 500
+  }
+}
+
+type FetchErrorLike = Partial<{
+  status: number
+  statusCode: number
+  statusMessage: string
+  data: unknown
+  message: string
+  response: {
+    headers?: Headers
+  }
+}>
+
+export function toHttpError(error: unknown): HttpError {
+  if (error instanceof HttpError) {
+    return error
+  }
+
+  const maybeFetchError = error as FetchErrorLike
+  const status =
+    maybeFetchError.status ??
+    maybeFetchError.statusCode ??
+    (error instanceof Error ? extractStatusFromMessage(error.message) : null) ??
+    500
+
+  const message =
+    maybeFetchError.statusMessage ??
+    maybeFetchError.message ??
+    (error instanceof Error ? error.message : undefined) ??
+    `HTTP ${status}`
+
+  const headers = maybeFetchError.response?.headers
+  const data = maybeFetchError.data
+
+  return new HttpError({
+    status,
+    message,
+    data,
+    headers,
+  })
+}
+
+export function isHttpError(error: unknown): error is HttpError {
+  return error instanceof HttpError
+}
+
+function extractStatusFromMessage(message: string): number | null {
+  const match = message.match(/HTTP\\s+(\\d{3})/)
+  if (!match) return null
+  const parsed = Number.parseInt(match[1], 10)
+  return Number.isFinite(parsed) ? parsed : null
+}

--- a/packages/frontend/features/activities/domain/activity.ts
+++ b/packages/frontend/features/activities/domain/activity.ts
@@ -1,0 +1,8 @@
+import type { ActivityDetail as BackendActivityDetail } from '~/generated/api/schemas'
+
+// フロントエンドで利用する Activity 詳細の型。
+// Backend の API 型と差分がない場合はエイリアスで集約する。
+export type ActivityDetail = BackendActivityDetail
+
+// API レスポンスとの違いが出た場合は、上記の型を置き換え、
+// Repository 内で map して返却する。

--- a/packages/frontend/features/activities/repositories/activity-detail-repository.ts
+++ b/packages/frontend/features/activities/repositories/activity-detail-repository.ts
@@ -1,0 +1,14 @@
+import type { ActivityDetailResponse } from '~/generated/api/schemas'
+import type { ActivityDetail } from '../domain/activity'
+
+export class ActivityDetailRepository {
+  async fetch(activityId: string): Promise<ActivityDetail> {
+    const requestFetch = useRequestFetch()
+    const response = await requestFetch<ActivityDetailResponse>(
+      `/api/activities/${activityId}`
+    )
+
+    // 差分整形が必要になった場合はここで map する。
+    return response.data.activity
+  }
+}

--- a/packages/frontend/features/activities/repositories/activity-detail-repository.ts
+++ b/packages/frontend/features/activities/repositories/activity-detail-repository.ts
@@ -1,14 +1,19 @@
 import type { ActivityDetailResponse } from '~/generated/api/schemas'
+import { toHttpError } from '~/errors/http-error'
 import type { ActivityDetail } from '../domain/activity'
 
 export class ActivityDetailRepository {
   async fetch(activityId: string): Promise<ActivityDetail> {
-    const requestFetch = useRequestFetch()
-    const response = await requestFetch<ActivityDetailResponse>(
-      `/api/activities/${activityId}`
-    )
+    const fetcher = useRequestFetch()
+    try {
+      const response = await fetcher<ActivityDetailResponse>(
+        `/api/activities/${activityId}`
+      )
 
-    // 差分整形が必要になった場合はここで map する。
-    return response.data.activity
+      // 差分整形が必要になった場合はここで map する。
+      return response.data.activity
+    } catch (error) {
+      throw toHttpError(error)
+    }
   }
 }


### PR DESCRIPTION
## 背景 (SOW: CHASE-170)
- ActivityDetailページが直接 `useFetch` で `/api/activities/:id` を叩いており、テスト環境でBFF未起動時に404/timeoutとなる課題がありました。
- SOWで定義した方針に従い、フロントエンドにRepository層を挟み、ページはRepository経由でデータ取得する形に見直します。ドメイン型をfeatures配下に集約し、テストはRepositoryモックで安定化します。

## 変更内容
- `features/activities/domain/activity.ts` でActivityDetailのフロントエンド用型を定義（Orval生成型のエイリアス）。
- `features/activities/repositories/activity-detail-repository.ts` を追加し、Nuxt APIルート経由で詳細を取得するRepositoryをクラスとして実装。
- `ActivityDetailPage.vue` でRepositoryインスタンスを用いた `useAsyncData` に切り替え、従来のUIロジックを保持。
- `ActivityDetailHeader` の型参照をドメイン型へ変更。
- ページテストをRepositoryモックに差し替え、コンポーネント直マウントでルート依存を排除。
- Docs整備（APIガイド/ページガイド/フォルダ構成/テスト戦略）にRepository+domain配置とモック方針を追記。
- SOW文書を指摘事項に沿って更新（features配下の型/Repository配置、TODO解消）。

## テスト
- `pnpm --filter frontend test packages/frontend/components/pages/activities/detail/__tests__/activity-detail.test.ts`
- `pnpm format`
- `pnpm lint`
