### PR TITLE
CHASE-185: ActivityルートのDI簡素化とテスト初期化の改善

### DIFF
--- a/docs/sow/20251210-CHASE-185.md
+++ b/docs/sow/20251210-CHASE-185.md
@@ -1,0 +1,305 @@
+# SOW: CHASE-185: ActivityルートのDI簡素化とテスト初期化の改善
+
+## プロジェクト概要
+
+**課題ID**: CHASE-185
+**作成日**: 2025-12-10
+**種別**: リファクタリング / 実装改善
+
+## 1. 背景と目的
+
+### 背景
+
+Activity系のルート (`packages/backend/src/features/activities/presentation/routes.ts`) をHono経由でテストする際、`createActivityPresentationRoutes` に全UseCaseインスタンスを直渡ししている。
+
+現状の問題点:
+
+1. **テスト初期化の肥大化**
+   - `createActivityPresentationRoutes` のシグネチャが3つのUseCaseを個別に要求
+   - テストごとに `DrizzleActivityQueryRepository` と3つのUseCaseをインスタンス化
+   - テストで使用しないUseCaseも初期化が必要
+
+2. **保守コストの増大**
+   - 機能追加でUseCaseが増えるたび、全テストの呼び出し引数を増やす必要がある
+   - 例えば翻訳機能用UseCaseを追加すると、全テストファイルに影響
+
+3. **外部サービス差し替えの柔軟性維持**
+   - 翻訳クライアント/GitHubなどの外部サービスをスタブで差し替える柔軟さは維持したい
+
+### 目的
+
+1. ルートのシグネチャを簡素化し、テスト初期化を短縮
+2. 外部サービス差し替えの柔軟性を維持
+3. 新規UseCase追加時の修正箇所を1か所に集約
+
+## 2. 実装スコープ
+
+### 実装対象
+
+- **デフォルト依存セット + 部分オーバーライド方式** の採用
+  - 依存組み立て関数 `buildActivityDeps()` を新設
+  - `createActivityPresentationRoutes(overrides?: Partial)` へシグネチャ変更
+  - テスト用ファクトリ関数 `createActivityTestApp()` の新設
+
+### 更新可能な項目
+
+1. `createActivityPresentationRoutes` の引数形式変更
+2. 既存テストの初期化コード簡素化
+
+### 実装除外項目
+
+- 外部アダプタ（翻訳クライアント等）のスタブ化（現時点でActivityルートでは外部APIを直接使用していない）
+- 軽量サービスレジストリ方式（オーバーエンジニアリングを避ける）
+- データベースやUseCaseのロジック変更
+
+## 3. 技術仕様
+
+### API仕様
+
+本タスクはAPI仕様の変更なし（内部リファクタリング）。
+
+### データベース操作
+
+本タスクはデータベース操作の変更なし。
+
+### アーキテクチャ設計
+
+#### 採用方式: デフォルト依存セット + 部分オーバーライド
+
+Plane課題の検討案1と2を組み合わせた方式を採用:
+
+1. **依存組み立て関数 (`buildActivityDeps`)**: デフォルトの依存関係を構築
+2. **テスト用ファクトリ (`createActivityTestApp`)**: テスト用アプリのセットアップを1行化
+
+#### 依存関係フロー
+
+```
+[本番環境]
+index.ts
+  └── buildActivityDeps() → デフォルト依存セット
+       └── createActivityPresentationRoutes(deps)
+            └── Honoルート
+
+[テスト環境]
+test.ts
+  └── createActivityTestApp({ useCaseOverrides: { someUseCase: fake } })
+       └── buildActivityDeps({ useCaseOverrides }) → オーバーライド適用
+            └── createActivityPresentationRoutes(deps)
+                 └── Honoルート + globalJWTAuth
+```
+
+## 4. 実装ファイル一覧
+
+### 新規作成ファイル
+
+```
+packages/backend/src/features/activities/
+├── application/
+│   └── activity-deps.ts                 # 依存組み立て関数
+│       - buildActivityDeps({ useCaseOverrides }?: Partial)
+│       - ActivityDeps型定義
+│       - デフォルト依存セットの構築
+│
+└── presentation/
+    └── test-helpers/
+        └── create-activity-test-app.ts  # テスト用ファクトリ
+            - createActivityTestApp(overrides?: Partial)
+            - OpenAPIHono + globalJWTAuth + routes セットアップ
+```
+
+### 更新対象ファイル
+
+```
+packages/backend/src/features/activities/
+├── index.ts
+│   - buildActivityDepsのre-export
+│   - createActivityPresentationRoutesの呼び出し方法変更
+│
+├── presentation/
+│   ├── routes.ts
+│   │   - シグネチャを createActivityPresentationRoutes(deps: ActivityDeps) に変更
+│   │
+│   └── routes/
+│       ├── activities/
+│       │   ├── index.ts
+│       │   │   - createActivitiesRoutes の引数を deps: Pick<ActivityDeps, "..."＞ に変更
+│       │   └── __tests__/
+│       │       └── index.test.ts
+│       │           - createActivityTestApp() を使用した初期化に変更
+│       │
+│       └── data-source-activities/
+│           ├── index.ts
+│           │   - createDataSourceActivitiesRoutes の引数を deps: Pick<ActivityDeps, "..."＞ に変更
+│           └── __tests__/
+│               └── index.test.ts
+│                   - createActivityTestApp() を使用した初期化に変更
+```
+
+## 5. テスト戦略
+
+### Component Test（Presentation層）
+
+既存のテストケースはそのまま維持。初期化部分のみ変更:
+
+**変更前:**
+```typescript
+const repository = new DrizzleActivityQueryRepository()
+const listUserActivitiesUseCase = new ListUserActivitiesUseCase(repository)
+const getActivityDetailUseCase = new GetActivityDetailUseCase(repository)
+const listDataSourceActivitiesUseCase = new ListDataSourceActivitiesUseCase(repository)
+
+app = new OpenAPIHono()
+app.use("*", globalJWTAuth)
+app.route(
+  "/",
+  createActivityPresentationRoutes(
+    listUserActivitiesUseCase,
+    getActivityDetailUseCase,
+    listDataSourceActivitiesUseCase,
+  ),
+)
+```
+
+**変更後:**
+```typescript
+app = createActivityTestApp()
+```
+
+### Unit Test（Service層）
+
+- 今回は実装しない（既存テストで十分カバレッジあり）
+
+### Unit Test（Repository層）
+
+- 今回は実装しない（変更なし）
+
+### テストファイルの検証
+
+- 既存テストが全て通ることを確認
+- テスト初期化コードが簡素化されていることを確認
+
+## 6. 受け入れ基準
+
+### 機能要件
+
+- [ ] `buildActivityDeps()` が全UseCaseのデフォルトインスタンスを返す
+- [ ] `createActivityPresentationRoutes(deps)` が依存オブジェクトを受け取る形式に変更されている
+- [ ] `createActivityTestApp()` がテスト用Honoアプリを返す
+- [ ] `createActivityTestApp({ useCaseOverrides })` で特定のUseCaseを差し替えできる
+- [ ] 既存のAPIエンドポイントの動作に変更がない
+
+### 非機能要件
+
+- [ ] 既存のテストが全て通る
+- [ ] lint/formatエラーがない
+- [ ] TypeScript型エラーがない
+- [ ] テスト初期化コードが短縮されている
+
+### セキュリティ要件
+
+- [ ] 本タスクはセキュリティに関する変更なし
+
+## 7. 実装手順
+
+### Phase 1: 依存組み立て関数の作成
+
+- 1-1. `ActivityDeps` 型を定義
+- 1-2. `buildActivityDeps()` 関数を実装
+- 1-3. format, lint, コミット
+
+### Phase 2: ルート関数のシグネチャ変更
+
+- 2-1. `createActivityPresentationRoutes` を `deps: ActivityDeps` 引数に変更
+- 2-2. `createActivitiesRoutes` を `deps: Pick<ActivityDeps, ...>` 引数に変更
+- 2-3. `createDataSourceActivitiesRoutes` を `deps: Pick<ActivityDeps, ...>` 引数に変更
+- 2-4. `index.ts` の呼び出し方法を更新
+- 2-5. format, lint, コミット
+
+### Phase 3: テストファクトリの作成と既存テスト更新
+
+- 3-1. `createActivityTestApp()` 関数を実装
+- 3-2. `routes/activities/__tests__/index.test.ts` を更新
+- 3-3. `routes/data-source-activities/__tests__/index.test.ts` を更新
+- 3-4. 全テスト実行・確認
+- 3-5. format, lint, コミット
+
+## 8. 型定義詳細
+
+### ActivityDeps型
+
+```typescript
+export interface ActivityDeps {
+  listUserActivitiesUseCase: ListUserActivitiesUseCase
+  getActivityDetailUseCase: GetActivityDetailUseCase
+  listDataSourceActivitiesUseCase: ListDataSourceActivitiesUseCase
+}
+```
+
+### buildActivityDeps関数
+
+```typescript
+export interface BuildActivityDepsOptions {
+  useCaseOverrides?: Partial<ActivityDeps>
+}
+
+export function buildActivityDeps(
+  options?: BuildActivityDepsOptions,
+): ActivityDeps {
+  const activityQueryRepository = new DrizzleActivityQueryRepository()
+
+  return {
+    listUserActivitiesUseCase:
+      options?.useCaseOverrides?.listUserActivitiesUseCase ??
+      new ListUserActivitiesUseCase(activityQueryRepository),
+    getActivityDetailUseCase:
+      options?.useCaseOverrides?.getActivityDetailUseCase ??
+      new GetActivityDetailUseCase(activityQueryRepository),
+    listDataSourceActivitiesUseCase:
+      options?.useCaseOverrides?.listDataSourceActivitiesUseCase ??
+      new ListDataSourceActivitiesUseCase(activityQueryRepository),
+  }
+}
+```
+
+### createActivityTestApp関数
+
+```typescript
+export interface CreateActivityTestAppOptions {
+  useCaseOverrides?: Partial<ActivityDeps>
+}
+
+export function createActivityTestApp(
+  options?: CreateActivityTestAppOptions,
+): OpenAPIHono {
+  const deps = buildActivityDeps({
+    useCaseOverrides: options?.useCaseOverrides,
+  })
+
+  const app = new OpenAPIHono()
+  app.use("*", globalJWTAuth)
+  app.route("/", createActivityPresentationRoutes(deps))
+
+  return app
+}
+```
+
+## 9. リスク・考慮事項
+
+### 技術的リスク
+
+- **シグネチャ変更の影響範囲**: ルート関数のシグネチャ変更が他の呼び出し箇所に影響を与える可能性
+- **型安全性**: オーバーライド時の型チェックが正しく機能するか
+
+### 軽減策
+
+- 段階的実装: 依存関数 → ルート変更 → テスト更新の順で実装
+- 各フェーズ後にテスト実行で回帰確認
+- TypeScriptの型システムによる安全性確保
+
+### 将来の拡張性
+
+本方式は以下の拡張に対応可能:
+
+1. **新規UseCase追加時**: `ActivityDeps` 型と `buildActivityDeps` に追加するだけ
+2. **外部アダプタのスタブ化**: `options.adapterOverrides` を追加して対応可能
+3. **リポジトリの差し替え**: `options.repositoryOverrides` を追加して対応可能

--- a/docs/task-logs/CHASE-185/20251210-01-log.md
+++ b/docs/task-logs/CHASE-185/20251210-01-log.md
@@ -1,0 +1,64 @@
+# 作業ログ: CHASE-185 ActivityルートのDI簡素化とテスト初期化の改善
+
+## 作業情報
+
+- **作業日**: 2025-12-10
+- **課題ID**: CHASE-185
+- **SOW**: `docs/sow/20251210-CHASE-185.md`
+
+## 実装計画
+
+### 概要
+
+Activity系ルートのDI方式を「デフォルト依存セット + 部分オーバーライド方式」に変更し、テスト初期化を簡素化する。
+
+### 作業チェックリスト
+
+#### Phase 1: 依存組み立て関数の作成
+
+- [x] `ActivityDeps` 型を定義
+- [x] `buildActivityDeps()` 関数を実装
+- [x] `packages/backend/src/features/activities/application/activity-deps.ts` に作成
+
+#### Phase 2: ルート関数のシグネチャ変更
+
+- [x] `createActivityPresentationRoutes` を `deps: ActivityDeps` 引数に変更
+- [x] `createActivitiesRoutes` を `deps: Pick<ActivityDeps, ...>` 引数に変更
+- [x] `createDataSourceActivitiesRoutes` を `deps: Pick<ActivityDeps, ...>` 引数に変更
+- [x] `index.ts` の呼び出し方法を更新
+
+#### Phase 3: テストファクトリの作成と既存テスト更新
+
+- [x] `createActivityTestApp()` 関数を実装 (`presentation/test-helpers/create-activity-test-app.ts`)
+- [x] `routes/activities/__tests__/index.test.ts` を更新
+- [x] `routes/data-source-activities/__tests__/index.test.ts` を更新
+
+#### 最終確認
+
+- [x] 全テスト実行・確認
+- [x] Lint/Format確認
+- [ ] コミット・Push・PR作成
+
+## 変更対象ファイル一覧
+
+### 新規作成
+
+1. `packages/backend/src/features/activities/application/activity-deps.ts`
+2. `packages/backend/src/features/activities/presentation/test-helpers/create-activity-test-app.ts`
+
+### 更新
+
+1. `packages/backend/src/features/activities/index.ts`
+2. `packages/backend/src/features/activities/presentation/routes.ts`
+3. `packages/backend/src/features/activities/presentation/routes/activities/index.ts`
+4. `packages/backend/src/features/activities/presentation/routes/data-source-activities/index.ts`
+5. `packages/backend/src/features/activities/presentation/routes/activities/__tests__/index.test.ts`
+6. `packages/backend/src/features/activities/presentation/routes/data-source-activities/__tests__/index.test.ts`
+
+## 作業メモ
+
+- なし
+
+## 懸念事項
+
+- なし

--- a/docs/task-logs/CHASE-185/20251210-01-log.md
+++ b/docs/task-logs/CHASE-185/20251210-01-log.md
@@ -37,7 +37,11 @@ Activity系ルートのDI方式を「デフォルト依存セット + 部分オ�
 
 - [x] 全テスト実行・確認
 - [x] Lint/Format確認
-- [ ] コミット・Push・PR作成
+- [x] コミット・Push・PR作成
+
+## PR
+
+- https://github.com/tri-star/chase-light/pull/206
 
 ## 変更対象ファイル一覧
 

--- a/packages/backend/src/features/activities/application/activity-deps.ts
+++ b/packages/backend/src/features/activities/application/activity-deps.ts
@@ -1,0 +1,46 @@
+import { DrizzleActivityQueryRepository } from "../infra"
+import {
+  GetActivityDetailUseCase,
+  ListDataSourceActivitiesUseCase,
+  ListUserActivitiesUseCase,
+} from "./use-cases"
+
+/**
+ * Activity機能の依存関係を定義する型
+ */
+export interface ActivityDeps {
+  listUserActivitiesUseCase: ListUserActivitiesUseCase
+  getActivityDetailUseCase: GetActivityDetailUseCase
+  listDataSourceActivitiesUseCase: ListDataSourceActivitiesUseCase
+}
+
+/**
+ * buildActivityDeps関数のオプション
+ */
+export interface BuildActivityDepsOptions {
+  useCaseOverrides?: Partial<ActivityDeps>
+}
+
+/**
+ * Activity機能の依存関係を構築する
+ *
+ * @param options - オプション設定。useCaseOverridesで特定のUseCaseを差し替え可能
+ * @returns Activity機能の依存関係セット
+ */
+export function buildActivityDeps(
+  options?: BuildActivityDepsOptions,
+): ActivityDeps {
+  const activityQueryRepository = new DrizzleActivityQueryRepository()
+
+  return {
+    listUserActivitiesUseCase:
+      options?.useCaseOverrides?.listUserActivitiesUseCase ??
+      new ListUserActivitiesUseCase(activityQueryRepository),
+    getActivityDetailUseCase:
+      options?.useCaseOverrides?.getActivityDetailUseCase ??
+      new GetActivityDetailUseCase(activityQueryRepository),
+    listDataSourceActivitiesUseCase:
+      options?.useCaseOverrides?.listDataSourceActivitiesUseCase ??
+      new ListDataSourceActivitiesUseCase(activityQueryRepository),
+  }
+}

--- a/packages/backend/src/features/activities/application/activity-deps.ts
+++ b/packages/backend/src/features/activities/application/activity-deps.ts
@@ -33,14 +33,15 @@ export function buildActivityDeps(
   const activityQueryRepository = new DrizzleActivityQueryRepository()
 
   return {
-    listUserActivitiesUseCase:
-      options?.useCaseOverrides?.listUserActivitiesUseCase ??
-      new ListUserActivitiesUseCase(activityQueryRepository),
-    getActivityDetailUseCase:
-      options?.useCaseOverrides?.getActivityDetailUseCase ??
-      new GetActivityDetailUseCase(activityQueryRepository),
-    listDataSourceActivitiesUseCase:
-      options?.useCaseOverrides?.listDataSourceActivitiesUseCase ??
-      new ListDataSourceActivitiesUseCase(activityQueryRepository),
+    listUserActivitiesUseCase: new ListUserActivitiesUseCase(
+      activityQueryRepository,
+    ),
+    getActivityDetailUseCase: new GetActivityDetailUseCase(
+      activityQueryRepository,
+    ),
+    listDataSourceActivitiesUseCase: new ListDataSourceActivitiesUseCase(
+      activityQueryRepository,
+    ),
+    ...options?.useCaseOverrides,
   }
 }

--- a/packages/backend/src/features/activities/application/index.ts
+++ b/packages/backend/src/features/activities/application/index.ts
@@ -1,1 +1,2 @@
 export * from "./use-cases"
+export * from "./activity-deps"

--- a/packages/backend/src/features/activities/index.ts
+++ b/packages/backend/src/features/activities/index.ts
@@ -1,37 +1,24 @@
-import { DrizzleActivityQueryRepository } from "./infra"
-import {
-  GetActivityDetailUseCase,
-  ListDataSourceActivitiesUseCase,
-  ListUserActivitiesUseCase,
-} from "./application/use-cases"
+import { buildActivityDeps } from "./application/activity-deps"
 import { createActivityPresentationRoutes } from "./presentation"
 
-const activityQueryRepository = new DrizzleActivityQueryRepository()
-
-const listUserActivitiesUseCase = new ListUserActivitiesUseCase(
-  activityQueryRepository,
-)
-const listDataSourceActivitiesUseCase = new ListDataSourceActivitiesUseCase(
-  activityQueryRepository,
-)
-const getActivityDetailUseCase = new GetActivityDetailUseCase(
-  activityQueryRepository,
-)
-
-const activityRoutes = createActivityPresentationRoutes(
-  listUserActivitiesUseCase,
-  getActivityDetailUseCase,
-  listDataSourceActivitiesUseCase,
-)
+const activityRoutes = createActivityPresentationRoutes(buildActivityDeps())
 
 export default activityRoutes
 
+export { buildActivityDeps } from "./application/activity-deps"
+export type {
+  ActivityDeps,
+  BuildActivityDepsOptions,
+} from "./application/activity-deps"
+
+export { createActivityPresentationRoutes } from "./presentation"
+
 export {
-  createActivityPresentationRoutes,
   ListUserActivitiesUseCase,
   ListDataSourceActivitiesUseCase,
   GetActivityDetailUseCase,
-  DrizzleActivityQueryRepository,
-}
+} from "./application/use-cases"
+
+export { DrizzleActivityQueryRepository } from "./infra"
 
 export * from "./domain"

--- a/packages/backend/src/features/activities/presentation/routes.ts
+++ b/packages/backend/src/features/activities/presentation/routes.ts
@@ -1,28 +1,14 @@
 import { OpenAPIHono } from "@hono/zod-openapi"
-import type {
-  GetActivityDetailUseCase,
-  ListDataSourceActivitiesUseCase,
-  ListUserActivitiesUseCase,
-} from "../application/use-cases"
+import type { ActivityDeps } from "../application/activity-deps"
 import { createActivitiesRoutes } from "./routes/activities"
 import { createDataSourceActivitiesRoutes } from "./routes/data-source-activities"
 
-export function createActivityPresentationRoutes(
-  listUserActivitiesUseCase: ListUserActivitiesUseCase,
-  getActivityDetailUseCase: GetActivityDetailUseCase,
-  listDataSourceActivitiesUseCase: ListDataSourceActivitiesUseCase,
-) {
+export function createActivityPresentationRoutes(deps: ActivityDeps) {
   const app = new OpenAPIHono()
 
-  app.route(
-    "/activities",
-    createActivitiesRoutes(listUserActivitiesUseCase, getActivityDetailUseCase),
-  )
+  app.route("/activities", createActivitiesRoutes(deps))
 
-  app.route(
-    "/data-sources",
-    createDataSourceActivitiesRoutes(listDataSourceActivitiesUseCase),
-  )
+  app.route("/data-sources", createDataSourceActivitiesRoutes(deps))
 
   return app
 }

--- a/packages/backend/src/features/activities/presentation/routes/activities/__tests__/index.test.ts
+++ b/packages/backend/src/features/activities/presentation/routes/activities/__tests__/index.test.ts
@@ -1,14 +1,7 @@
 import { beforeEach, describe, expect, test } from "vitest"
-import { OpenAPIHono } from "@hono/zod-openapi"
+import type { OpenAPIHono } from "@hono/zod-openapi"
 import { setupComponentTest, TestDataFactory } from "../../../../../../test"
-import { createActivityPresentationRoutes } from "../../../routes"
-import {
-  ListUserActivitiesUseCase,
-  GetActivityDetailUseCase,
-  ListDataSourceActivitiesUseCase,
-} from "../../../../application/use-cases"
-import { DrizzleActivityQueryRepository } from "../../../../infra"
-import { globalJWTAuth } from "../../../../../identity"
+import { createActivityTestApp } from "../../../test-helpers/create-activity-test-app"
 import { AuthTestHelper } from "../../../../../identity/test-helpers/auth-test-helper"
 import type { User } from "../../../../../identity/domain/user"
 import { ACTIVITY_STATUS, ACTIVITY_TYPE } from "../../../../domain"
@@ -101,23 +94,7 @@ describe("Activities API", () => {
     })
     await TestDataFactory.createTestUserWatch(otherUser.id, otherDataSource.id)
 
-    const repository = new DrizzleActivityQueryRepository()
-    const listUserActivitiesUseCase = new ListUserActivitiesUseCase(repository)
-    const getActivityDetailUseCase = new GetActivityDetailUseCase(repository)
-    const listDataSourceActivitiesUseCase = new ListDataSourceActivitiesUseCase(
-      repository,
-    )
-
-    app = new OpenAPIHono()
-    app.use("*", globalJWTAuth)
-    app.route(
-      "/",
-      createActivityPresentationRoutes(
-        listUserActivitiesUseCase,
-        getActivityDetailUseCase,
-        listDataSourceActivitiesUseCase,
-      ),
-    )
+    app = createActivityTestApp()
   })
 
   test("GET /activities でウォッチしているcompletedアクティビティ一覧を取得できる", async () => {

--- a/packages/backend/src/features/activities/presentation/routes/activities/index.ts
+++ b/packages/backend/src/features/activities/presentation/routes/activities/index.ts
@@ -1,10 +1,7 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi"
 import { z } from "@hono/zod-openapi"
 import { requireAuth } from "../../../../identity/middleware/jwt-auth.middleware"
-import type {
-  GetActivityDetailUseCase,
-  ListUserActivitiesUseCase,
-} from "../../../application/use-cases"
+import type { ActivityDeps } from "../../../application/activity-deps"
 import {
   activityDetailResponseSchema,
   activityListRequestSchema,
@@ -22,9 +19,12 @@ const createApiErrorResponse = (code: string, message: string) => ({
 })
 
 export function createActivitiesRoutes(
-  listUserActivitiesUseCase: ListUserActivitiesUseCase,
-  getActivityDetailUseCase: GetActivityDetailUseCase,
+  deps: Pick<
+    ActivityDeps,
+    "listUserActivitiesUseCase" | "getActivityDetailUseCase"
+  >,
 ) {
+  const { listUserActivitiesUseCase, getActivityDetailUseCase } = deps
   const app = new OpenAPIHono()
 
   const listActivitiesRoute = createRoute({

--- a/packages/backend/src/features/activities/presentation/routes/data-source-activities/__tests__/index.test.ts
+++ b/packages/backend/src/features/activities/presentation/routes/data-source-activities/__tests__/index.test.ts
@@ -1,14 +1,7 @@
 import { beforeEach, describe, expect, test } from "vitest"
-import { OpenAPIHono } from "@hono/zod-openapi"
+import type { OpenAPIHono } from "@hono/zod-openapi"
 import { setupComponentTest, TestDataFactory } from "../../../../../../test"
-import { createActivityPresentationRoutes } from "../../../routes"
-import {
-  ListUserActivitiesUseCase,
-  GetActivityDetailUseCase,
-  ListDataSourceActivitiesUseCase,
-} from "../../../../application/use-cases"
-import { DrizzleActivityQueryRepository } from "../../../../infra"
-import { globalJWTAuth } from "../../../../../identity"
+import { createActivityTestApp } from "../../../test-helpers/create-activity-test-app"
 import { AuthTestHelper } from "../../../../../identity/test-helpers/auth-test-helper"
 import type { User } from "../../../../../identity/domain/user"
 import { ACTIVITY_STATUS, ACTIVITY_TYPE } from "../../../../domain"
@@ -100,23 +93,7 @@ describe("Data Source Activities API", () => {
     })
     await TestDataFactory.createTestUserWatch(otherUser.id, otherDataSource.id)
 
-    const repository = new DrizzleActivityQueryRepository()
-    const listUserActivitiesUseCase = new ListUserActivitiesUseCase(repository)
-    const getActivityDetailUseCase = new GetActivityDetailUseCase(repository)
-    const listDataSourceActivitiesUseCase = new ListDataSourceActivitiesUseCase(
-      repository,
-    )
-
-    app = new OpenAPIHono()
-    app.use("*", globalJWTAuth)
-    app.route(
-      "/",
-      createActivityPresentationRoutes(
-        listUserActivitiesUseCase,
-        getActivityDetailUseCase,
-        listDataSourceActivitiesUseCase,
-      ),
-    )
+    app = createActivityTestApp()
   })
 
   test("GET /data-sources/{id}/activities で対象データソースのアクティビティを取得できる", async () => {

--- a/packages/backend/src/features/activities/presentation/routes/data-source-activities/index.ts
+++ b/packages/backend/src/features/activities/presentation/routes/data-source-activities/index.ts
@@ -1,7 +1,7 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi"
 import { z } from "@hono/zod-openapi"
 import { requireAuth } from "../../../../identity/middleware/jwt-auth.middleware"
-import type { ListDataSourceActivitiesUseCase } from "../../../application/use-cases"
+import type { ActivityDeps } from "../../../application/activity-deps"
 import {
   activityListRequestSchema,
   dataSourceActivityListResponseSchema,
@@ -10,8 +10,9 @@ import {
 import { mapDataSourceActivitiesResultToResponse } from "../../utils/response-mapper"
 
 export function createDataSourceActivitiesRoutes(
-  listDataSourceActivitiesUseCase: ListDataSourceActivitiesUseCase,
+  deps: Pick<ActivityDeps, "listDataSourceActivitiesUseCase">,
 ) {
+  const { listDataSourceActivitiesUseCase } = deps
   const app = new OpenAPIHono()
 
   const dataSourceParamSchema = z

--- a/packages/backend/src/features/activities/presentation/test-helpers/create-activity-test-app.ts
+++ b/packages/backend/src/features/activities/presentation/test-helpers/create-activity-test-app.ts
@@ -1,0 +1,44 @@
+import { OpenAPIHono } from "@hono/zod-openapi"
+import { globalJWTAuth } from "../../../identity"
+import type { ActivityDeps } from "../../application/activity-deps"
+import { buildActivityDeps } from "../../application/activity-deps"
+import { createActivityPresentationRoutes } from "../routes"
+
+/**
+ * createActivityTestApp関数のオプション
+ */
+export interface CreateActivityTestAppOptions {
+  useCaseOverrides?: Partial<ActivityDeps>
+}
+
+/**
+ * Activityテスト用のHonoアプリケーションを作成する
+ *
+ * @param options - オプション設定。useCaseOverridesで特定のUseCaseを差し替え可能
+ * @returns 設定済みのOpenAPIHonoアプリケーション
+ *
+ * @example
+ * ```ts
+ * // デフォルトの依存関係を使用
+ * const app = createActivityTestApp()
+ *
+ * // 特定のUseCaseをモックに差し替え
+ * const mockUseCase = { execute: vi.fn() }
+ * const app = createActivityTestApp({
+ *   useCaseOverrides: { listUserActivitiesUseCase: mockUseCase }
+ * })
+ * ```
+ */
+export function createActivityTestApp(
+  options?: CreateActivityTestAppOptions,
+): OpenAPIHono {
+  const deps = buildActivityDeps({
+    useCaseOverrides: options?.useCaseOverrides,
+  })
+
+  const app = new OpenAPIHono()
+  app.use("*", globalJWTAuth)
+  app.route("/", createActivityPresentationRoutes(deps))
+
+  return app
+}


### PR DESCRIPTION
## Summary

- Activity系ルートのDI方式を「デフォルト依存セット + 部分オーバーライド方式」に変更
- `buildActivityDeps()`関数でデフォルト依存を構築、テストでは`useCaseOverrides`で差し替え可能
- テスト初期化を`createActivityTestApp()`で1行化し、保守コストを削減

## Changes

### 新規ファイル
- `packages/backend/src/features/activities/application/activity-deps.ts`: 依存組み立て関数
- `packages/backend/src/features/activities/presentation/test-helpers/create-activity-test-app.ts`: テスト用ファクトリ

### 変更ファイル
- ルート関数のシグネチャを`deps: ActivityDeps`形式に変更
- 既存テストを新方式に移行

## Test plan

- [x] 既存のActivity系テストが全て通過
- [x] Lint/Formatエラーなし
- [x] TypeScript型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)