### PR TITLE
CHASE-197：本番ビルド時はsourcemapを含めない対応

### DIFF
--- a/packages/backend/infrastructure/sam-template.yaml
+++ b/packages/backend/infrastructure/sam-template.yaml
@@ -25,7 +25,10 @@ Globals:
         DB_NAME: ""
         DB_SSL: !Ref UseAws
         OPENAI_API_KEY: ""
-        NODE_OPTIONS: !If [UseParamsSecretsExtension, '--import=/opt/nodejs/otel-setup.mjs', '']
+        NODE_OPTIONS: !Join
+          - " "
+          - - !If [UseParamsSecretsExtension, "--import=/opt/nodejs/otel-setup.mjs", ""]
+            - !If [IsProd, "", "--enable-sourcemaps"]
         ATTR_SERVICE_NAME: "chase-light-backend"
     Tracing: Active
 
@@ -51,6 +54,7 @@ Parameters:
 
 Conditions:
   UseParamsSecretsExtension: !Equals [!Ref UseAws, "true"]
+  IsProd: !Equals [!Ref Stage, "prod"]
 
 Resources:
   BackendHttpApi:

--- a/packages/backend/scripts/build-lambda.ts
+++ b/packages/backend/scripts/build-lambda.ts
@@ -4,13 +4,8 @@ import fs from "node:fs"
 import path from "node:path"
 import { execSync } from "node:child_process"
 import { fileURLToPath } from "node:url"
-import {
-  defaultEsbuildConfig,
-  defaultPackageJsonConfig,
-  lambdaConfigs,
-  lambdaDefaults,
-  type LambdaConfig,
-} from "./lambda-config.js"
+import dotenv from "dotenv"
+import { buildLambdaConfig, type LambdaConfig } from "./lambda-config.js"
 import {
   loadLockfile,
   resolveDependencyVersions,
@@ -19,6 +14,14 @@ import {
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
+
+dotenv.config({ path: path.join(__dirname, "..", ".env") })
+const {
+  lambdaConfigs,
+  lambdaDefaults,
+  defaultEsbuildConfig,
+  defaultPackageJsonConfig,
+} = buildLambdaConfig()
 
 const DIST_DIR = path.join(__dirname, "..", "dist", "lambda")
 
@@ -79,6 +82,9 @@ const buildEsbuildCommand = (
   const externalArgs = externalPackages
     .map((pkg) => `--external:${pkg}`)
     .join(" ")
+  const sourcemapArg = defaultEsbuildConfig.sourcemap
+    ? `--sourcemap=${defaultEsbuildConfig.sourcemap}`
+    : ""
 
   return [
     "pnpm",
@@ -89,7 +95,7 @@ const buildEsbuildCommand = (
     `--platform=${defaultEsbuildConfig.platform}`,
     `--target=${defaultEsbuildConfig.target}`,
     `--format=${defaultEsbuildConfig.format}`,
-    `--sourcemap=${defaultEsbuildConfig.sourcemap}`,
+    sourcemapArg,
     `--minify=${defaultEsbuildConfig.minify}`,
     externalArgs,
   ]

--- a/packages/backend/scripts/lambda-config.ts
+++ b/packages/backend/scripts/lambda-config.ts
@@ -9,104 +9,117 @@ export type LambdaConfig = {
   skipDefaultExternalPackages?: boolean
 }
 
-export const lambdaDefaults = {
-  importer: "packages/backend",
-  defaultDependencies: ["@aws-sdk/client-ssm", "pg", "drizzle-orm", "dotenv"],
-  defaultExternalPackages: [
-    "@aws-sdk/*",
-    "aws-sdk",
-    "pg",
-    "drizzle-orm",
-    "dotenv",
-  ],
-}
+export function buildLambdaConfig() {
+  const appStage = process.env.APP_STAGE ?? process.env.STAGE
+  const isProd = appStage === "prod"
 
-export const lambdaConfigs: Record<string, LambdaConfig> = {
-  "list-detect-targets": {
-    name: "list-detect-targets-lambda",
-    description: "List detect targets for monitoring",
-    entryPoint: "./src/features/detection/workers/list-detect-targets/index.ts",
-  },
-  "detect-datasource-updates": {
-    name: "detect-datasource-updates-lambda",
-    description: "Detect updates for a data source",
-    entryPoint:
-      "./src/features/detection/workers/detect-datasource-updates/index.ts",
-    additionalDependencies: ["@octokit/rest", "jsonwebtoken", "jwks-rsa"],
-    externalPackages: ["@octokit/rest", "jsonwebtoken", "jwks-rsa"],
-  },
-  "process-updates": {
-    name: "process-updates-lambda",
-    description:
-      "Process updates for events (SQS handler and direct invocation)",
-    entryPoint: "./src/features/detection/workers/process-updates/index.ts",
-    additionalDependencies: ["openai", "jsonwebtoken", "jwks-rsa"],
-    externalPackages: ["openai", "jsonwebtoken", "jwks-rsa"],
-  },
-  "generate-digest-notifications": {
-    name: "generate-digest-notifications-lambda",
-    description:
-      "Generate digest notifications for subscribed users based on activities",
-    entryPoint:
-      "./src/features/notification/workers/generate-digest-notifications/index.ts",
-    additionalDependencies: ["luxon", "jsonwebtoken", "jwks-rsa"],
-    externalPackages: ["luxon", "jsonwebtoken", "jwks-rsa"],
-  },
-  "translate-activity-body": {
-    name: "translate-activity-body-lambda",
-    description: "Translate activity body content via SQS trigger",
-    entryPoint:
-      "./src/features/activities/workers/translate-activity-body/index.ts",
-    additionalDependencies: ["openai"],
-    externalPackages: ["openai"],
-  },
-  api: {
-    name: "backend-api-lambda",
-    description: "Hono-based API handler",
-    entryPoint: "./src/index.ts",
-    skipDefaultDependencies: true,
-    additionalDependencies: [
-      "hono",
-      "@hono/zod-openapi",
-      "@hono/zod-validator",
-      "@scalar/hono-api-reference",
+  const lambdaDefaults = {
+    importer: "packages/backend",
+    defaultDependencies: ["@aws-sdk/client-ssm", "pg", "drizzle-orm", "dotenv"],
+    defaultExternalPackages: [
+      "@aws-sdk/*",
+      "aws-sdk",
       "pg",
       "drizzle-orm",
       "dotenv",
-      "jsonwebtoken",
-      "jwks-rsa",
-      "zod",
-      "uuidv7",
     ],
-    externalPackages: [
-      "pg",
-      "drizzle-orm",
-      "dotenv",
-      "jsonwebtoken",
-      "jwks-rsa",
-    ],
-    dependencyOverrides: {
-      // hono 4.x requires @hono/node-server only for local dev; Lambdaでは不要
-      hono: "4.10.2",
+  }
+
+  const lambdaConfigs: Record<string, LambdaConfig> = {
+    "list-detect-targets": {
+      name: "list-detect-targets-lambda",
+      description: "List detect targets for monitoring",
+      entryPoint:
+        "./src/features/detection/workers/list-detect-targets/index.ts",
     },
-  },
-}
+    "detect-datasource-updates": {
+      name: "detect-datasource-updates-lambda",
+      description: "Detect updates for a data source",
+      entryPoint:
+        "./src/features/detection/workers/detect-datasource-updates/index.ts",
+      additionalDependencies: ["@octokit/rest", "jsonwebtoken", "jwks-rsa"],
+      externalPackages: ["@octokit/rest", "jsonwebtoken", "jwks-rsa"],
+    },
+    "process-updates": {
+      name: "process-updates-lambda",
+      description:
+        "Process updates for events (SQS handler and direct invocation)",
+      entryPoint: "./src/features/detection/workers/process-updates/index.ts",
+      additionalDependencies: ["openai", "jsonwebtoken", "jwks-rsa"],
+      externalPackages: ["openai", "jsonwebtoken", "jwks-rsa"],
+    },
+    "generate-digest-notifications": {
+      name: "generate-digest-notifications-lambda",
+      description:
+        "Generate digest notifications for subscribed users based on activities",
+      entryPoint:
+        "./src/features/notification/workers/generate-digest-notifications/index.ts",
+      additionalDependencies: ["luxon", "jsonwebtoken", "jwks-rsa"],
+      externalPackages: ["luxon", "jsonwebtoken", "jwks-rsa"],
+    },
+    "translate-activity-body": {
+      name: "translate-activity-body-lambda",
+      description: "Translate activity body content via SQS trigger",
+      entryPoint:
+        "./src/features/activities/workers/translate-activity-body/index.ts",
+      additionalDependencies: ["openai"],
+      externalPackages: ["openai"],
+    },
+    api: {
+      name: "backend-api-lambda",
+      description: "Hono-based API handler",
+      entryPoint: "./src/index.ts",
+      skipDefaultDependencies: true,
+      additionalDependencies: [
+        "hono",
+        "@hono/zod-openapi",
+        "@hono/zod-validator",
+        "@scalar/hono-api-reference",
+        "pg",
+        "drizzle-orm",
+        "dotenv",
+        "jsonwebtoken",
+        "jwks-rsa",
+        "zod",
+        "uuidv7",
+      ],
+      externalPackages: [
+        "pg",
+        "drizzle-orm",
+        "dotenv",
+        "jsonwebtoken",
+        "jwks-rsa",
+      ],
+      dependencyOverrides: {
+        // hono 4.x requires @hono/node-server only for local dev; Lambdaでは不要
+        hono: "4.10.2",
+      },
+    },
+  }
 
-// デフォルトのesbuild設定
-export const defaultEsbuildConfig = {
-  platform: "node",
-  target: "node20",
-  format: "esm",
-  bundle: true,
-  sourcemap: "external",
-  minify: false,
-}
+  // デフォルトのesbuild設定
+  const defaultEsbuildConfig = {
+    platform: "node",
+    target: "node20",
+    format: "esm",
+    bundle: true,
+    sourcemap: isProd ? undefined : "external",
+    minify: false,
+  }
 
-// デフォルトのpackage.json設定
-export const defaultPackageJsonConfig = {
-  version: "1.0.0",
-  type: "module",
-  engines: {
-    node: ">=20.0.0",
-  },
+  // デフォルトのpackage.json設定
+  const defaultPackageJsonConfig = {
+    version: "1.0.0",
+    type: "module",
+    engines: {
+      node: ">=20.0.0",
+    },
+  }
+
+  return {
+    lambdaConfigs,
+    lambdaDefaults,
+    defaultEsbuildConfig,
+    defaultPackageJsonConfig,
+  }
 }

--- a/packages/frontend/infrastructure/template.yaml
+++ b/packages/frontend/infrastructure/template.yaml
@@ -50,6 +50,7 @@ Parameters:
 
 Conditions:
   UseParamsSecretsExtension: !Equals [!Ref UseAws, 'true']
+  IsProd: !Equals [!Ref Stage, 'prod']
 
 Globals:
   Function:
@@ -68,7 +69,10 @@ Globals:
     Environment:
       Variables:
         NODE_ENV: production
-        NODE_OPTIONS: '--import=/opt/nodejs/otel-setup.mjs'
+        NODE_OPTIONS: !Join
+          - ' '
+          - - '--import=/opt/nodejs/otel-setup.mjs'
+            - !If [IsProd, '', '--enable-sourcemaps']
 
 Resources:
   AssetsBucket:

--- a/packages/frontend/nuxt.config.ts
+++ b/packages/frontend/nuxt.config.ts
@@ -1,5 +1,8 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 
+const appStage = process.env.APP_STAGE ?? process.env.STAGE
+const isProd = appStage === 'prod'
+
 export default defineNuxtConfig({
   compatibilityDate: '2025-05-15',
   devtools: { enabled: true },
@@ -45,5 +48,5 @@ export default defineNuxtConfig({
   storybook: {
     enabled: false, // 開発サーバーとの同時起動はエラーが起きるので停止
   },
-  sourcemap: { client: 'hidden', server: true },
+  sourcemap: isProd ? false : { client: 'hidden', server: true },
 })


### PR DESCRIPTION
今後Sentryを導入する際に、本番ビルド時はhidden + Sentryに送信後ソースマップ削除を行う想定